### PR TITLE
Exclude Trolltech.conf in Xenial build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,9 @@ install-common:
 	install -D appvm-scripts/etc/tmpfiles.d/qubes-session.conf $(DESTDIR)/$(USRLIBDIR)/tmpfiles.d/qubes-session.conf
 	install -m 0644 -D appvm-scripts/etc/securitylimits.d/90-qubes-gui.conf $(DESTDIR)/etc/security/limits.d/90-qubes-gui.conf
 	install -D appvm-scripts/etc/xdgautostart/qubes-pulseaudio.desktop $(DESTDIR)/etc/xdg/autostart/qubes-pulseaudio.desktop
+ifneq ($(shell lsb_release -cs), xenial)
 	install -D appvm-scripts/etc/xdg/Trolltech.conf $(DESTDIR)/etc/xdg/Trolltech.conf
+endif
 	install -D appvm-scripts/qubes-gui-vm.gschema.override $(DESTDIR)$(DATADIR)/glib-2.0/schemas/20_qubes-gui-vm.gschema.override
 	install -m 0644 -D appvm-scripts/etc/qubes-rpc/qubes.SetMonitorLayout $(DESTDIR)/etc/qubes-rpc/qubes.SetMonitorLayout
 	install -D window-icon-updater/icon-sender $(DESTDIR)/usr/lib/qubes/icon-sender


### PR DESCRIPTION
After trying various alternatives, it seems to me that the cleanest solution here is just to do nothing for Xenial, and to use the Ubuntu Trolltech.conf without override. If there are display issues, (and I haven't seen any in testing), it's just a standard Trolltech problem, easily resolvable by user.