### PR TITLE
Provide XDG_DATA_DIRS in Xenial. Also update deb package to 3.0 quilt)

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -2,4 +2,18 @@ ifeq ($(PACKAGE_SET),vm)
 RPM_SPEC_FILES := rpm_spec/gui-vm.spec
 ARCH_BUILD_DIRS := archlinux
 DEBIAN_BUILD_DIRS := debian
+ifneq ($(filter $(DISTRIBUTION), debian qubuntu),)
+SOURCE_COPY_IN := source-debian-quilt-copy-in
+
+source-debian-quilt-copy-in: VERSION = $(shell cat $(ORIG_SRC)/version)
+source-debian-quilt-copy-in: ORIG_FILE = "$(CHROOT_DIR)/$(DIST_SRC)/../qubes-gui-agent_$(VERSION).orig.tar.gz"
+ifneq (,$(findstring $(DIST),xenial))
+source-debian-quilt-copy-in:
+	-$(shell $(ORIG_SRC)/debian-quilt $(ORIG_SRC)/series-debian-vm.conf $(CHROOT_DIR)/$(DIST_SRC)/debian/patches)
+	tar cfz $(ORIG_FILE) --exclude-vcs --exclude=rpm --exclude=pkgs --exclude=deb --exclude=debian -C $(CHROOT_DIR)/$(DIST_SRC) .
+else
+source-debian-quilt-copy-in:
+	tar cfz $(ORIG_FILE) --exclude-vcs --exclude=rpm --exclude=pkgs --exclude=deb --exclude=debian -C $(CHROOT_DIR)/$(DIST_SRC) .
+endif
+endif
 endif

--- a/debian-quilt
+++ b/debian-quilt
@@ -1,0 +1,31 @@
+#!/bin/bash
+# vim: set ts=4 sw=4 sts=4 et :
+#
+# Given a series.conf file and debian patches directory, patches
+# are copied to debian patch directory
+
+USAGE="${0} <series.conf> <patchdir>"
+
+set -e
+set -o pipefail
+
+DIR="${0%/*}"
+SERIES_CONF="${1}"
+PATCH_DIR="${2}"
+
+if test $# -lt 2 || [ ! -e "${SERIES_CONF}" ] || [ ! -d "${PATCH_DIR}" ] ; then
+	echo "${USAGE}" >&2
+	exit 1
+fi
+
+# Clear patch series.conf file
+rm -f "${PATCH_DIR}/series"
+touch "${PATCH_DIR}/series"
+
+while read patch_file
+do
+    if [ -e "${DIR}/${patch_file}" ]; then
+        echo -e "${patch_file##*/}" >> "${PATCH_DIR}/series"
+        cp "${DIR}/${patch_file}" "${PATCH_DIR}"
+    fi
+done < "${SERIES_CONF}"

--- a/debian/rules
+++ b/debian/rules
@@ -4,6 +4,7 @@
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
 
+include /usr/share/dpkg/default.mk
 export DESTDIR=$(shell pwd)/debian/qubes-gui-agent
 export LIBDIR=/usr/lib
 

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)

--- a/patches.debian/01_setXDG_DIR.patch
+++ b/patches.debian/01_setXDG_DIR.patch
@@ -1,0 +1,12 @@
+Index: gui-agent-linux/appvm-scripts/etc/X11/Xsession.d/25xdg-qubes-settings
+===================================================================
+--- gui-agent-linux.orig/appvm-scripts/etc/X11/Xsession.d/25xdg-qubes-settings
++++ gui-agent-linux/appvm-scripts/etc/X11/Xsession.d/25xdg-qubes-settings
+@@ -17,3 +17,7 @@ if [ -x /usr/bin/xsettingsd ]; then
+     /usr/bin/xsettingsd &
+ fi
+ 
++if [ "$XDG_DATA_DIRS" = "" ]; then
++    XDG_DATA_DIRS='/usr/share/ubuntu/:/usr/share/gnome/:/usr/local/share/:/usr/share/'
++    export XDG_DATA_DIRS
++fi

--- a/series-debian-vm.conf
+++ b/series-debian-vm.conf
@@ -1,0 +1,1 @@
+patches.debian/01_setXDG_DIR.patch


### PR DESCRIPTION
This should be final part of xenial build, fixing QubesOS/qubes-issues#2430

Package format has been changed to use quilt. The debian changelog will need to be updated as part of final package build.