### PR TITLE
Fix build for Trusty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ install-common:
 		$(DESTDIR)/etc/security/limits.d/90-qubes-gui.conf
 	install -m 0644 -D appvm-scripts/etc/xdgautostart/qubes-pulseaudio.desktop \
 		$(DESTDIR)/etc/xdg/autostart/qubes-pulseaudio.desktop
-ifneq ($(shell lsb_release -cs), xenial)
+ifneq ($(shell lsb_release -is), Ubuntu)
 	install -m 0644 -D appvm-scripts/etc/xdg/Trolltech.conf \
 		$(DESTDIR)/etc/xdg/Trolltech.conf
 endif

--- a/patches.debian/01_setXDG_DIR.patch
+++ b/patches.debian/01_setXDG_DIR.patch
@@ -2,10 +2,11 @@ Index: gui-agent-linux/appvm-scripts/etc/X11/Xsession.d/25xdg-qubes-settings
 ===================================================================
 --- gui-agent-linux.orig/appvm-scripts/etc/X11/Xsession.d/25xdg-qubes-settings
 +++ gui-agent-linux/appvm-scripts/etc/X11/Xsession.d/25xdg-qubes-settings
-@@ -17,3 +17,7 @@ if [ -x /usr/bin/xsettingsd ]; then
+@@ -16,3 +16,8 @@ if [ -x /usr/bin/xsettingsd ]; then
+     installConfigurationFile "Xresources"
      /usr/bin/xsettingsd &
  fi
- 
++
 +if [ "$XDG_DATA_DIRS" = "" ]; then
 +    XDG_DATA_DIRS='/usr/share/ubuntu/:/usr/share/gnome/:/usr/local/share/:/usr/share/'
 +    export XDG_DATA_DIRS


### PR DESCRIPTION
Tidy Debian patch for XDG_DATA_DIRS
Stop Ubuntu builds from overwriting Trolltech.conf

One of fixes for QubesOS/qubes-issues#2608