### PR TITLE
Fix Ubuntu template builds; Apply XDG changes to trusty.

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,11 +1,22 @@
 ifeq ($(PACKAGE_SET),vm)
-RPM_SPEC_FILES := rpm_spec/gui-agent.spec
-ARCH_BUILD_DIRS := archlinux
-DEBIAN_BUILD_DIRS := debian
+  RPM_SPEC_FILES := rpm_spec/gui-agent.spec
 
-ifneq (,$(findstring $(DIST),xenial))
-SOURCE_COPY_IN := source-debian-quilt-copy-in
+  ifneq ($(filter $(DISTRIBUTION), debian qubuntu),)
+    DEBIAN_BUILD_DIRS := debian
+    SOURCE_COPY_IN := source-debian-quilt-copy-in
+  endif
+ 
+  ARCH_BUILD_DIRS := archlinux
+endif
+
+source-debian-quilt-copy-in: VERSION = $(shell cat $(ORIG_SRC)/version)
+source-debian-quilt-copy-in: ORIG_FILE = "$(CHROOT_DIR)/$(DIST_SRC)/../qubes-gui-agent_$(VERSION).orig.tar.gz"
 source-debian-quilt-copy-in:
+	if [ $(DISTRIBUTION) == qubuntu ] ; then \
+                sed -i /Trolltech.conf/d $(CHROOT_DIR)/$(DIST_SRC)/debian/qubes-gui-agent.install ;\
+	fi
 	-$(shell $(ORIG_SRC)/debian-quilt $(ORIG_SRC)/series-debian-vm.conf $(CHROOT_DIR)/$(DIST_SRC)/debian/patches)
-endif
-endif
+	tar cfz $(ORIG_FILE) --exclude-vcs --exclude=rpm --exclude=pkgs --exclude=deb --exclude=debian -C $(CHROOT_DIR)/$(DIST_SRC) .
+
+
+# vim: filetype=make


### PR DESCRIPTION
4.0 template builds use `<package>.install` files with dh_install.  The
differences between Debian and Ubuntu packages also need to be represented
in these files.

The XDG changes for Xenial are also beneficial in Trusty.  Applying to
both flavors allowed for a more standard Makefile.builder layout.