### PR TITLE
Fix Ubuntu template builds; apply XDG changes for all Ubuntu templates.

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,11 +1,17 @@
 ifeq ($(PACKAGE_SET),vm)
-RPM_SPEC_FILES := rpm_spec/gui-agent.spec
-ARCH_BUILD_DIRS := archlinux
-DEBIAN_BUILD_DIRS := debian
+  RPM_SPEC_FILES := rpm_spec/gui-agent.spec
+  ARCH_BUILD_DIRS := archlinux
+  DEBIAN_BUILD_DIRS := debian
 
-ifneq (,$(findstring $(DIST),xenial))
-SOURCE_COPY_IN := source-debian-quilt-copy-in
+  ifneq (,$(findstring $(DISTRIBUTION),qubuntu))
+    SOURCE_COPY_IN := source-debian-quilt-copy-in
+  endif
+endif
+
+
 source-debian-quilt-copy-in:
+	sed -i /Trolltech.conf/d $(CHROOT_DIR)/$(DIST_SRC)/debian/qubes-gui-agent.install
 	-$(shell $(ORIG_SRC)/debian-quilt $(ORIG_SRC)/series-debian-vm.conf $(CHROOT_DIR)/$(DIST_SRC)/debian/patches)
-endif
-endif
+	 
+# vim: filetype=make
+


### PR DESCRIPTION
4.0 template builds use `<package>.install` files with dh_install.
The differences between Debian and Ubuntu packages also need to be
represented in these files.

The XDG changes for Xenial are also beneficial in Trusty.