### PR TITLE
CLIPBOARD_DATA: send window id, and ignore window id in incoming pastes

### DIFF
--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -709,15 +709,15 @@ void process_xevent_configure(Ghandles * g, XID window,
     send_pixmap_mfns(g, window);
 }
 
-void send_clipboard_data(libvchan_t *vchan, char *data, int len)
+void send_clipboard_data(libvchan_t *vchan, XID window, char *data, uint32_t len)
 {
     struct msg_hdr hdr;
     hdr.type = MSG_CLIPBOARD_DATA;
+    hdr.window = window;
     if (len > MAX_CLIPBOARD_SIZE)
+    {
         len = MAX_CLIPBOARD_SIZE;
-    else
-        hdr.window = len;
-    hdr.window = len;
+    }
     hdr.untrusted_len = len;
     write_struct(vchan, hdr);
     write_data(vchan, (char *) data, len);
@@ -788,7 +788,7 @@ void process_xevent_selection(Ghandles * g, XSelectionEvent * ev)
                 Utf8_string_atom, Qprop,
                 g->stub_win, CurrentTime);
     else
-        send_clipboard_data(g->vchan, (char *) data, len);
+        send_clipboard_data(g->vchan, g->stub_win, (char *) data, len);
     /* even if the clipboard owner does not support UTF8 and we requested
        XA_STRING, it is fine - ascii is legal UTF8 */
     XFree(data);
@@ -1747,7 +1747,7 @@ void do_execute(char *user, char *cmd)
 }
 
 #define CLIPBOARD_4WAY
-void handle_clipboard_req(Ghandles * g, XID UNUSED(winid))
+void handle_clipboard_req(Ghandles * g, XID winid)
 {
     Atom Clp;
     Atom QProp = XInternAtom(g->display, "QUBES_SELECTION", False);
@@ -1763,14 +1763,14 @@ void handle_clipboard_req(Ghandles * g, XID UNUSED(winid))
         fprintf(stderr, "clipboard req, owner=0x%x\n",
                 (int) owner);
     if (owner == None) {
-        send_clipboard_data(g->vchan, NULL, 0);
+        send_clipboard_data(g->vchan, winid, NULL, 0);
         return;
     }
     XConvertSelection(g->display, Clp, Targets, QProp,
             g->stub_win, CurrentTime);
 }
 
-void handle_clipboard_data(Ghandles * g, int len)
+void handle_clipboard_data(Ghandles * g, XID UNUSED(winid), unsigned int len)
 {
     Atom Clp = XInternAtom(g->display, "CLIPBOARD", False);
 
@@ -1881,7 +1881,7 @@ void handle_message(Ghandles * g)
             handle_clipboard_req(g, hdr.window);
             break;
         case MSG_CLIPBOARD_DATA:
-            handle_clipboard_data(g, hdr.window);
+            handle_clipboard_data(g, hdr.window, hdr.untrusted_len);
             break;
         case MSG_KEYMAP_NOTIFY:
             handle_keymap_notify(g);


### PR DESCRIPTION
This PR is linked to a matching PR to `qubes-gui-daemon`, see https://github.com/QubesOS/qubes-gui-daemon/pull/15/ for background.

It makes `send_clipboard_data` send the window id in the `window` field and the length of copied data in the `untrusted_len` field rather than sending the length in both.

It also touches on `handle_clipboard_data` to make it use the `untrusted_len` field for determining how much data to copy instead of using the `window` field. I also changed `len` in that function signature to take an `unsigned int` instead of a `signed int`, since that seemed more appropriate (please bear with me if that was incorrect).

