### PR TITLE
icon-sender: prefer xcffib module over xpyb

### DIFF
--- a/window-icon-updater/icon-sender
+++ b/window-icon-updater/icon-sender
@@ -27,11 +27,11 @@
 # Usage: qrexec-client-vm dom0 qubes.WindowIconUpdater ./icon-sender
 
 try:
-    import xcb
-    from xcb import xproto
-except ImportError:
     import xcffib as xcb
     from xcffib import xproto
+except ImportError:
+    import xcb
+    from xcb import xproto
 
 import sys
 import struct


### PR DESCRIPTION
xpyb in Fedora 26 (and probably others) have problems with parsing X
events, like this:

    Traceback (most recent call last):
      File "/usr/lib/qubes/icon-sender", line 155, in <module>
        retriever.watch_and_send_icons()
      File "/usr/lib/qubes/icon-sender", line 136, in watch_and_send_icons
        [xproto.EventMask.SubstructureNotify])
      File "/usr/lib64/python2.7/site-packages/xcb/xproto.py", line 1400, in ChangeWindowAttributesChecked
        for elt in xcb.Iterator(value_list, 15, 'value_list', False):
    xcb.Exception: Too few items in 'value_list' list (expect 15).

QubesOS/qubes-issues#1495