### PR TITLE
desktop flavor: specific XFCE make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,10 +96,12 @@ install-rh-agent: appvm install-common
 		$(DESTDIR)/etc/X11/xinit/xinitrc.d/20qt-x11-no-mitshm.sh
 	install -D appvm-scripts/etc/X11/xinit/xinitrc.d/20qt-gnome-desktop-session-id.sh \
 		$(DESTDIR)/etc/X11/xinit/xinitrc.d/20qt-gnome-desktop-session-id.sh
-	install -D appvm-scripts/etc/X11/xinit/xinitrc.d/50-xfce-desktop.sh \
-                $(DESTDIR)/etc/X11/xinit/xinitrc.d/50-xfce-desktop.sh
 	install -m 0644 -D appvm-scripts/etc/X11/Xwrapper.config \
 		$(DESTDIR)/etc/X11/Xwrapper.config
+
+install-xfce:
+	install -D appvm-scripts/etc/X11/xinit/xinitrc.d/50-xfce-desktop.sh \
+		$(DESTDIR)/etc/X11/xinit/xinitrc.d/50-xfce-desktop.sh
 
 install-debian: appvm install-common install-pulseaudio
 	install -D appvm-scripts/etc/X11/xinit/xinitrc.d/qubes-keymap.sh \

--- a/rpm_spec/gui-agent.spec
+++ b/rpm_spec/gui-agent.spec
@@ -104,7 +104,7 @@ make appvm
 
 %install
 rm -rf $RPM_BUILD_ROOT
-make install DESTDIR=$RPM_BUILD_ROOT \
+make install install-xfce DESTDIR=$RPM_BUILD_ROOT \
                      LIBDIR=%{_libdir} \
                      DATADIR=%{_datadir} \
                      PA_VER=%{pa_ver}


### PR DESCRIPTION
I put the XFCE script in a separate make target. Notably because of Archlinux. If I understand correctly the packaging of Archlinux, each package is made with specific make target. It will allow to do the packaging for the XFCE script with simply make install-xfce. For Fedora and Debian, we could think in the future for a make target like install-flavors. What do you think?