### PR TITLE
XFCE: export QT_QPA_PLATFORMTHEME=qt5ct to init qt5ct properly

### DIFF
--- a/appvm-scripts/etc/X11/xinit/xinitrc.d/50-xfce-desktop.sh
+++ b/appvm-scripts/etc/X11/xinit/xinitrc.d/50-xfce-desktop.sh
@@ -19,4 +19,6 @@ if which xdg-user-dirs-update >/dev/null 2>&1; then
     xdg-user-dirs-update
 fi
 
+export QT_QPA_PLATFORMTHEME=qt5ct
+
 xfsettingsd &


### PR DESCRIPTION
Set the initial variable QT_QPA_PLATFORMTHEME needed by qt5ct