### PR TITLE
Dynamic video ram

### DIFF
--- a/appvm-scripts/etc/X11/xorg-qubes.conf.template
+++ b/appvm-scripts/etc/X11/xorg-qubes.conf.template
@@ -11,7 +11,7 @@ EndSection
 Section "Device"
         Identifier  "Videocard0"
         Driver      "dummyqbs"
-	VideoRam 65536
+        VideoRam %MEM%
 EndSection
 
 Section "Monitor"

--- a/appvm-scripts/usrbin/qubes-run-xorg.sh
+++ b/appvm-scripts/usrbin/qubes-run-xorg.sh
@@ -36,6 +36,10 @@ HSYNC_END=$((HSYNC_START+1))
 VREFR_START=$(($CLOCK*1000000/$HTOTAL/$VTOTAL))
 VREFR_END=$((VREFR_START+1))
 
+# Add extra memory to allow dynamic connection of extra monitor. Have space for
+# one FHD monitor, or multiple smaller.
+MEM=$(($MEM + 1920 * 1080 * 4 / 1024))
+
 sed -e  s/%MEM%/$MEM/ \
         -e  s/%DEPTH%/$DEPTH/ \
         -e  s/%MODELINE%/"$MODELINE"/ \


### PR DESCRIPTION
Restore dynamic video ram calculation. But to allow dynamic display connection, add some extra ram - enough for one more Full HD display. If more is needed, we can adjust it later (make it configurable somewhere), but for now attaching more displays will require VM restart. Previous hardcoded value was enough for two 4K displays, regardless of when they were attached.

Fixes QubesOS/qubes-issues#3174
Fixes QubesOS/qubes-issues#3634