### PR TITLE
spec.in: python-xcffib -> python2-xcffib for Fedora >=28

### DIFF
--- a/rpm_spec/gui-vm.spec
+++ b/rpm_spec/gui-vm.spec
@@ -59,7 +59,11 @@ Requires:	xen-qubes-vm-essentials
 Requires:	xorg-x11-drv-dummy
 Requires:	xorg-x11-xinit
 Requires:	qubes-libvchan-%{backend_vmm}
-Requires:	python-xcffib
+%if 0%{?fedora} >= 28
+Requires:     python2-xcffib
+%else
+Requires:     python-xcffib
+%endif
 
 # The vchan sink needs .h files from pulseaudio sources
 # that are not exported by any *-devel packages; thus they are internal and


### PR DESCRIPTION
(cherry picked from commit 84b10aa7ca200173ba2974a5a3fd96c1709de760)