### PR TITLE
Make it work with xorg-server 1.20 on Archlinux

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -59,7 +59,7 @@ make appvm
 package_qubes-vm-gui() {
 
 depends=('xorg-xinit' 'libxcomposite' 'zenity' 'qubes-libvchan-xen' 'python2-xcffib'
-		'xorg-server>=1.19.0' 'xorg-server<1.20.0'
+		'xorg-server>=1.20.0' 'xorg-server<1.21.0'
 		'qubes-vm-core>=3.0.14'
 		)
 install=PKGBUILD.install


### PR DESCRIPTION
Currently you can't upgrade Archlinux without skipping the xserver update. This PR fixes it. Seems to work for me.