### PR TITLE
Remove unnessecary pulseaudio message

### DIFF
--- a/pulse/module-vchan-sink.c
+++ b/pulse/module-vchan-sink.c
@@ -254,12 +254,14 @@ static int write_to_vchan(libvchan_t *ctrl, char *buf, int size)
 		errno = EAGAIN;
 		full++;
 	}
+	
+	return l;
 }
 
 static int process_sink_render(struct userdata *u)
 {
 	pa_assert(u);
-
+	
 	if (u->memchunk_sink.length <= 0)
 		pa_sink_render(u->sink, libvchan_buffer_space(u->play_ctrl), &u->memchunk_sink);
 

--- a/pulse/module-vchan-sink.c
+++ b/pulse/module-vchan-sink.c
@@ -254,12 +254,6 @@ static int write_to_vchan(libvchan_t *ctrl, char *buf, int size)
 		errno = EAGAIN;
 		full++;
 	}
-	if ((all % 8000) == 0) {
-		pa_log
-		    ("write_to_vchan: all=%d waited=%d nonwaited=%d full=%d\n",
-		     all, waited, nonwaited, full);
-	}
-	return l;
 }
 
 static int process_sink_render(struct userdata *u)


### PR DESCRIPTION
In pulse/module-vchan-sink.c unnessecary pulseaudio messages are
given. These are used for "debugging weird cases we haven't seen
in years". This creates noise in logs.

Fixes https://github.com/QubesOS/qubes-issues/issues/3933.

(sorry in the commit message it just has #3993 not the link to qubes-issues)