### PR TITLE
Bump Arch pulseaudio to 12.2 too

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -78,7 +78,7 @@ package_qubes-vm-pulseaudio() {
 
 pkgdesc="Pulseaudio support for Qubes VM"
 depends=( 'alsa-lib' 'alsa-utils' 'pulseaudio-alsa'
-		'pulseaudio>=12.0' 'pulseaudio<12.1'
+		'pulseaudio>=12.0' 'pulseaudio<12.3'
 )
 install=PKGBUILD-pulseaudio.install
 pa_ver=`(pkg-config --modversion libpulse 2>/dev/null || echo 0.0) | cut -f 1 -d "-"`


### PR DESCRIPTION
Untested, but corresponds to https://github.com/QubesOS/qubes-gui-agent-linux/commit/a2db14cb91622c64d1172124b880802f6b8ecb94 and https://github.com/QubesOS/qubes-gui-agent-linux/commit/4ae178c2bafb3d02ef2f5d44fdaf19d29c0c7501