### PR TITLE
debian: bind to specific pulseaudio version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -82,6 +82,7 @@ Depends:
     pulseaudio,
     libpulse0,
     ${shlibs:Depends},
+    ${pulse:Depends},
 Replaces: qubes-gui-agent (<< 4.0.0-1)
 Breaks: qubes-gui-agent (<< 4.0.0-1)
 Description: Audio support for Qubes VM

--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,8 @@ include /usr/share/dpkg/default.mk
 export DESTDIR=$(shell pwd)/debian/tmp
 export LIBDIR=/usr/lib
 
+PA_VER=$(shell pkg-config --modversion libpulse | cut -d "-" -f 1 || echo 0.0)
+
 %:
 	dh $@ --with systemd,xsf
 
@@ -22,3 +24,7 @@ override_dh_systemd_start:
 
 override_dh_install:
 	dh_install --fail-missing
+
+override_dh_gencontrol:
+	echo "pulse:Depends=pulseaudio (>= $(PA_VER)), pulseaudio (<< $(PA_VER).1)" >> debian/pulseaudio-qubes.substvars
+	dh_gencontrol


### PR DESCRIPTION
Since the pulseaudio-qubes package ships a pulseaudio module linked for
specific version, it needs to specify that in dependencies - otherwise
updating one but not the other will result in broken audio.
Since pulseaudio package does not provide substvars itself (in fact
pulseaudio modules API is not meant for external packages), generate
it in debian/control.
The version in MAJOR.MINOR form is enough (no need to compare
debian_version), but since dependency syntax doesn't support partial
matches, add >= MAJOR.MINOR and << MAJOR.MINOR.1 entries.

The intention is to detect at installation time potential breakage,
especially on pulseaudio update.

Fixes QubesOS/qubes-issues#3532