### PR TITLE
Fix python-xcffib dependency

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -58,7 +58,7 @@ make appvm
 
 package_qubes-vm-gui() {
 
-depends=('xorg-xinit' 'libxcomposite' 'zenity' 'qubes-libvchan-xen' 'python3-xcffib'
+depends=('xorg-xinit' 'libxcomposite' 'zenity' 'qubes-libvchan-xen' 'python-xcffib'
 		'xorg-server>=1.20.1' 'xorg-server<1.20.2'
 		'qubes-vm-core>=3.0.14'
 		)


### PR DESCRIPTION
Fixes an invalid dependency on python3-xcffib (correct package name is
python-xcffib) which partially causes a build failure.