### PR TITLE
Bump xorg-server version

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -59,7 +59,7 @@ make appvm
 package_qubes-vm-gui() {
 
 depends=('xorg-xinit' 'libxcomposite' 'zenity' 'qubes-libvchan-xen' 'python-xcffib'
-		'xorg-server>=1.20.1' 'xorg-server<1.20.2'
+		'xorg-server>=1.20.3' 'xorg-server<1.20.4'
 		'qubes-vm-core>=3.0.14'
 		)
 install=PKGBUILD.install


### PR DESCRIPTION
Bump xorg-server version from 1.20.1 to 1.20.3

As a side note, after this change and the other changes I submitted, I was able to build the Arch template successfully, although I have not tested yet. But once this is merged in, the Arch template should build smoothly.