### PR TITLE
qubes-run-xorg: add configurable videoram overhead

### DIFF
--- a/appvm-scripts/usrbin/qubes-run-xorg
+++ b/appvm-scripts/usrbin/qubes-run-xorg
@@ -36,9 +36,17 @@ HSYNC_END=$((HSYNC_START+1))
 VREFR_START=$(($CLOCK*1000000/$HTOTAL/$VTOTAL))
 VREFR_END=$((VREFR_START+1))
 
-# Add extra memory to allow dynamic connection of extra monitor. Have space for
-# one FHD monitor, or multiple smaller.
-MEM=$(($MEM + 1920 * 1080 * 4 / 1024))
+# Add extra memory to allow dynamic connection of extra monitor.
+# By default, have space for one FHD monitor, or multiple smaller.
+MEM_MIN="$(qubesdb-read /qubes-gui-videoram-min 2>/dev/null)"
+MEM_OVERHEAD="$(qubesdb-read /qubes-gui-videoram-overhead 2>/dev/null)"
+: ${MEM_MIN:=0}
+: ${MEM_OVERHEAD:=$((1920 * 1080 * 4 / 1024))}
+
+MEM=$(($MEM + $MEM_OVERHEAD))
+if [ $MEM -lt $MEM_MIN ]; then
+    MEM=$MEM_MIN
+fi
 
 sed -e  s/%MEM%/$MEM/ \
         -e  s/%DEPTH%/$DEPTH/ \


### PR DESCRIPTION
When starting X server inside qube, a fixed amount of RAM is allocated
to be used for video buffer. By default, it is enough for the current
desktop (at the time of qube start) and another 1920x1080 desktop, which
may be hotplugged in the future. That is not enough for 4K external
monitor, but we cannot preallocate 4K video buffer for everyone (about
24MiB additional memory per qube).

Now we allocate max(current desktop + overhead, min), where min and
overhead are configurable by qubesdb entries /qubes-gui-videoram-min and
/qubes-gui-videoram-overhead. Default behaviour remains unchanged.

QubesOS/qubes-core-admin#240