### PR TITLE
Fix X11 session registration in logind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,15 @@ help:
 	    echo "make update-repo-installer -- copy dom0 rpms to installer repo"
 	    @exit 0;
 
-appvm: gui-agent/qubes-gui xf86-input-mfndev/src/.libs/qubes_drv.so \
+appvm: gui-agent/qubes-gui gui-common/qubes-gui-runuser \
+	xf86-input-mfndev/src/.libs/qubes_drv.so \
 	xf86-video-dummy/src/.libs/dummyqbs_drv.so pulse/module-vchan-sink.so
 
 gui-agent/qubes-gui:
 	(cd gui-agent; $(MAKE))
+
+gui-common/qubes-gui-runuser:
+	(cd gui-common; $(MAKE))
 
 xf86-input-mfndev/src/.libs/qubes_drv.so:
 	(cd xf86-input-mfndev && ./autogen.sh && ./configure && make LDFLAGS=-lu2mfn)
@@ -127,6 +131,7 @@ install-pulseaudio:
 
 install-common:
 	install -D gui-agent/qubes-gui $(DESTDIR)/usr/bin/qubes-gui
+	install -D gui-common/qubes-gui-runuser $(DESTDIR)/usr/bin/qubes-gui-runuser
 	install -D appvm-scripts/usrbin/qubes-session \
 		$(DESTDIR)/usr/bin/qubes-session
 	install -D appvm-scripts/usrbin/qubes-run-xorg \
@@ -167,4 +172,19 @@ endif
 		$(DESTDIR)/usr/lib/sysctl.d/30-qubes-gui-agent.conf
 	install -D -m 0644 appvm-scripts/usr/lib/modules-load.d/qubes-gui.conf \
 		$(DESTDIR)/usr/lib/modules-load.d/qubes-gui.conf
+	install -D -m 0644 appvm-scripts/lib/udev/rules.d/70-master-of-seat.rules \
+		$(DESTDIR)/lib/udev/rules.d/70-master-of-seat.rules
+ifeq ($(shell lsb_release -is), Debian)
+	install -D -m 0644 appvm-scripts/etc/pam.d/qubes-gui-agent.debian \
+		$(DESTDIR)/etc/pam.d/qubes-gui-agent
+else ifeq ($(shell lsb_release -is), Ubuntu)
+	install -D -m 0644 appvm-scripts/etc/pam.d/qubes-gui-agent.debian \
+		$(DESTDIR)/etc/pam.d/qubes-gui-agent
+else ifeq ($(shell lsb_release -is), Arch)
+	install -D -m 0644 appvm-scripts/etc/pam.d/qubes-gui-agent.archlinux \
+		$(DESTDIR)/etc/pam.d/qubes-gui-agent
+else
+	install -D -m 0644 appvm-scripts/etc/pam.d/qubes-gui-agent \
+		$(DESTDIR)/etc/pam.d/qubes-gui-agent
+endif
 	install -d $(DESTDIR)/var/log/qubes

--- a/appvm-scripts/etc/pam.d/qubes-gui-agent
+++ b/appvm-scripts/etc/pam.d/qubes-gui-agent
@@ -1,0 +1,9 @@
+#%PAM-1.0
+auth		sufficient	pam_rootok.so
+auth		substack	system-auth
+auth		include		postlogin
+account		sufficient	pam_succeed_if.so uid = 0 use_uid quiet
+account		include		system-auth
+password	include		system-auth
+session		include		system-auth
+session		include		postlogin

--- a/appvm-scripts/etc/pam.d/qubes-gui-agent.archlinux
+++ b/appvm-scripts/etc/pam.d/qubes-gui-agent.archlinux
@@ -1,0 +1,9 @@
+#%PAM-1.0
+auth		sufficient	pam_rootok.so
+# Uncomment the following line to implicitly trust users in the "wheel" group.
+#auth		sufficient	pam_wheel.so trust use_uid
+# Uncomment the following line to require a user to be in the "wheel" group.
+#auth		required	pam_wheel.so use_uid
+auth		include		system-login
+account		include         system-login
+session		include		system-login

--- a/appvm-scripts/etc/pam.d/qubes-gui-agent.debian
+++ b/appvm-scripts/etc/pam.d/qubes-gui-agent.debian
@@ -1,0 +1,11 @@
+#%PAM-1.0
+#
+# based on /etc/pam.d/su
+auth		sufficient	pam_rootok.so
+session     required    pam_env.so readenv=1
+session     required    pam_env.so readenv=1 envfile=/etc/default/locale
+session     required    pam_limits.so
+
+@include common-auth
+@include common-account
+@include common-session

--- a/appvm-scripts/lib/udev/rules.d/70-master-of-seat.rules
+++ b/appvm-scripts/lib/udev/rules.d/70-master-of-seat.rules
@@ -1,0 +1,5 @@
+# logind needs _some_ device with master-of-seat tag, to consider seat0 being a
+# graphical seat. Since there are not many devices in Qubes VM, lets use pcspkr
+# which is an input device, apparently.
+
+ENV{ID_PATH}=="platform-pcspkr", TAG+="master-of-seat"

--- a/appvm-scripts/qubes-gui-agent.service
+++ b/appvm-scripts/qubes-gui-agent.service
@@ -3,10 +3,15 @@ Description=Qubes GUI Agent
 After=qubes-meminfo-writer.service qubes-mount-dirs.service
 
 [Service]
+StandardInput=tty
+TTYPath=/dev/tty7
+# custom PATH for X session can be set with ENV_PATH; otherwise service's PATH
+# is inherited
+#Environment=ENV_PATH=/usr/local/bin:/usr/bin:/bin
 # pretend tha user is at local console
 ExecStartPre=/bin/mkdir -p /var/run/console ; /bin/touch /var/run/console/user
-# clean env
 ExecStart=/usr/bin/qubes-gui $GUI_OPTS
+# clean env
 ExecStopPost=/bin/rm -f /tmp/qubes-session-env /tmp/qubes-session-waiter
 StandardOutput=syslog
 Environment=DISPLAY=:0

--- a/appvm-scripts/usrbin/qubes-run-xorg
+++ b/appvm-scripts/usrbin/qubes-run-xorg
@@ -66,11 +66,6 @@ if [ -f /etc/X11/Xsession ]; then
     fi
 fi
 
-# Make qubes input socket readable by user in case Xorg is not running as
-# root (debian for example)
-chown root:user /var/run/xf86-qubes-socket
-chmod 770 /var/run/xf86-qubes-socket
-
 export XDG_SEAT=seat0 XDG_SESSION_CLASS=user DISPLAY=:0
 
 # Defaults value in case default-user value is not available
@@ -78,6 +73,10 @@ DEFAULT_USER="$(qubesdb-read /default-user 2>/dev/null)"
 if [ -z "$DEFAULT_USER" ];then
     DEFAULT_USER="user"
 fi
+# Make qubes input socket readable by user in case Xorg is not running as
+# root (debian for example)
+chown "$DEFAULT_USER" /var/run/xf86-qubes-socket
+chmod 770 /var/run/xf86-qubes-socket
 
 if [ -x /bin/loginctl ]; then
     # logind needs at least one device with "master-of-seat" tag to

--- a/appvm-scripts/usrbin/qubes-run-xorg
+++ b/appvm-scripts/usrbin/qubes-run-xorg
@@ -71,7 +71,7 @@ fi
 chown root:user /var/run/xf86-qubes-socket
 chmod 770 /var/run/xf86-qubes-socket
 
-export XDG_SEAT=seat0 XDG_VTNR=7 XDG_SESSION_CLASS=user
+export XDG_SEAT=seat0 XDG_SESSION_CLASS=user DISPLAY=:0
 
 # Defaults value in case default-user value is not available
 DEFAULT_USER="$(qubesdb-read /default-user 2>/dev/null)"
@@ -79,4 +79,14 @@ if [ -z "$DEFAULT_USER" ];then
     DEFAULT_USER="user"
 fi
 
-exec su -l "$DEFAULT_USER" -c "/usr/bin/xinit $XSESSION -- $XORG :0 -nolisten tcp vt07 -wr -config xorg-qubes.conf > ~/.xsession-errors 2>&1"
+if [ -x /bin/loginctl ]; then
+    # logind needs at least one device with "master-of-seat" tag to
+    # consider this seat as graphical; we use pcspkr, for which we ship udev
+    # rules adding that tag
+    loginctl attach "$XDG_SEAT" /sys/devices/platform/pcspkr/input/*
+fi
+
+# Use sh -l here to load all session startup scripts (/etc/profile, ~/.profile
+# etc) to populate environment. This is the environment that will be used for
+# all user applications and qrexec calls.
+exec /usr/bin/qubes-gui-runuser "$DEFAULT_USER" /bin/sh -l -c "exec /usr/bin/xinit $XSESSION -- $XORG :0 -nolisten tcp vt07 -wr -config xorg-qubes.conf > ~/.xsession-errors 2>&1"

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: admin
 Priority: extra
 Maintainer: Davíð Steinn Geirsson <david@dsg.is>
 Build-Depends:
+    libpam0g-dev,
     libpulse-dev,
     libtool,
     automake,

--- a/debian/qubes-gui-agent.install
+++ b/debian/qubes-gui-agent.install
@@ -1,5 +1,6 @@
 etc/X11/*
 etc/profile.d/*
+etc/pam.d/qubes-gui-agent
 etc/security/limits.d/90-qubes-gui.conf
 etc/qubes-rpc/qubes.SetMonitorLayout
 etc/xdg/autostart/qubes-icon-sender.desktop
@@ -8,8 +9,10 @@ etc/xdg/Xresources
 etc/xdg/fonts.conf
 etc/xdg/xsettingsd
 lib/systemd/system/qubes-gui-agent.service
+lib/udev/rules.d/70-master-of-seat.rules
 usr/bin/qubes-change-keyboard-layout
 usr/bin/qubes-gui
+usr/bin/qubes-gui-runuser
 usr/bin/qubes-run-xorg
 usr/bin/qubes-session
 usr/bin/qubes-set-monitor-layout

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -1731,10 +1731,10 @@ void do_execute(char *user, char *cmd)
             perror("fork cmd");
             break;
         case 0:
-            for (i = 0; i < 256; i++)
+            for (i = 1; i < 256; i++)
                 close(i);
             fd = open("/dev/null", O_RDWR);
-            for (i = 0; i <= 2; i++)
+            for (i = 1; i <= 2; i++)
                 dup2(fd, i);
             signal(SIGCHLD, SIG_DFL);
             if (user)

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -29,7 +29,10 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <grp.h>
+#include <err.h>
 #include <X11/Xlib.h>
 #include <X11/Intrinsic.h>
 #include <X11/Xutil.h>
@@ -87,6 +90,7 @@ struct _global_handles {
     int log_level;
     int sync_all_modifiers;
     int composite_redirect_automatic;
+    pid_t x_pid;
 };
 
 struct window_data {
@@ -1723,27 +1727,42 @@ void handle_close(Ghandles * g, XID winid)
                 (int) winid);
 }
 
-void do_execute(char *user, char *cmd)
+/* start X server, returns its PID
+ */
+pid_t do_execute_xorg(
+        char *w_str, char *h_str, char *mem_str, char *depth_str)
 {
-    int i, fd;
-    switch (fork()) {
+    pid_t pid;
+    int fd;
+
+    pid = fork();
+    switch (pid) {
         case -1:
-            perror("fork cmd");
-            break;
+            perror("fork");
+            return -1;
         case 0:
-            for (i = 1; i < 256; i++)
-                close(i);
-            fd = open("/dev/null", O_RDWR);
-            for (i = 1; i <= 2; i++)
-                dup2(fd, i);
-            signal(SIGCHLD, SIG_DFL);
-            if (user)
-                execl("/bin/su", "su", "-", user, "-c", cmd, NULL);
-            else
-                execl("/bin/bash", "bash", "-c", cmd, NULL);
+            setenv("W", w_str, 1);
+            setenv("H", h_str, 1);
+            setenv("MEM", mem_str, 1);
+            setenv("DEPTH", depth_str, 1);
+            /* don't leak other FDs */
+            for (fd = 3; fd < 256; fd++)
+                close(fd);
+            execl("/usr/bin/qubes-run-xorg", "qubes-run-xorg", NULL);
             perror("execl cmd");
-            exit(1);
-        default:;
+            exit(127);
+        default:
+            return pid;
+    }
+}
+
+void terminate_and_cleanup_xorg(Ghandles *g) {
+    int status;
+
+    if (g->x_pid != (pid_t)-1) {
+        kill(g->x_pid, SIGTERM);
+        waitpid(g->x_pid, &status, 0);
+        g->x_pid = -1;
     }
 }
 
@@ -1898,20 +1917,21 @@ void handle_message(Ghandles * g)
     }
 }
 
-void get_xconf_and_run_x(libvchan_t *vchan)
+pid_t get_xconf_and_run_x(libvchan_t *vchan)
 {
     struct msg_xconf xconf;
-    char val[64];
+    char w_str[12], h_str[12], mem_str[12], depth_str[12];
+    pid_t x_pid;
     read_struct(vchan, xconf);
-    snprintf(val, sizeof(val), "%d", xconf.w);
-    setenv("W", val, 1);
-    snprintf(val, sizeof(val), "%d", xconf.h);
-    setenv("H", val, 1);
-    snprintf(val, sizeof(val), "%d", xconf.mem);
-    setenv("MEM", val, 1);
-    snprintf(val, sizeof(val), "%d", xconf.depth);
-    setenv("DEPTH", val, 1);
-    do_execute(NULL, "/usr/bin/qubes-run-xorg");
+    snprintf(w_str, sizeof(w_str), "%d", xconf.w);
+    snprintf(h_str, sizeof(h_str), "%d", xconf.h);
+    snprintf(mem_str, sizeof(mem_str), "%d", xconf.mem);
+    snprintf(depth_str, sizeof(depth_str), "%d", xconf.depth);
+    x_pid = do_execute_xorg(w_str, h_str, mem_str, depth_str);
+    if (x_pid == (pid_t)-1) {
+        errx(1, "X server startup failed");
+    }
+    return x_pid;
 }
 
 void send_protocol_version(libvchan_t *vchan)
@@ -1940,6 +1960,13 @@ void handle_guid_disconnect()
     /* discard */
     read_struct(g->vchan, xconf);
     send_all_windows_info(g);
+}
+
+void handle_sigterm()
+{
+    Ghandles *g = ghandles_for_vchan_reinitialize;
+    terminate_and_cleanup_xorg(g);
+    exit(0);
 }
 
 void usage()
@@ -2015,7 +2042,7 @@ int main(int argc, char **argv)
     saved_argv = argv;
     vchan_register_at_eof(handle_guid_disconnect);
     send_protocol_version(g.vchan);
-    get_xconf_and_run_x(g.vchan);
+    g.x_pid = get_xconf_and_run_x(g.vchan);
     mkghandles(&g);
     ghandles_for_vchan_reinitialize = &g;
     parse_args(&g, argc, argv);
@@ -2044,6 +2071,7 @@ int main(int argc, char **argv)
     }
     XAutoRepeatOff(g.display);
     signal(SIGCHLD, SIG_IGN);
+    signal(SIGTERM, handle_sigterm);
     windows_list = list_new();
     embeder_list = list_new();
     XSetErrorHandler(dummy_handler);

--- a/gui-common/Makefile
+++ b/gui-common/Makefile
@@ -1,4 +1,10 @@
-all:
-	@echo Doing nothing.
+CC ?= gcc
+CFLAGS += -g -Wall -Wextra -Werror -pie -fPIC
+LDLIBS = -lpam
+
+all: qubes-gui-runuser
+
+qubes-gui-runuser: qubes-gui-runuser.c
+
 clean:
 	rm -f *.o

--- a/gui-common/qubes-gui-runuser.c
+++ b/gui-common/qubes-gui-runuser.c
@@ -1,0 +1,324 @@
+/*
+ * The Qubes OS Project, http://www.qubes-os.org
+ *
+ * Copyright (C) 2018  Marek Marczykowski-Górecki  <marmarek@invisiblethingslab.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#define HAVE_PAM
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <errno.h>
+#include <grp.h>
+#include <pwd.h>
+#include <err.h>
+
+#ifdef HAVE_PAM
+#include <security/pam_appl.h>
+#endif
+
+pid_t child_pid = 0;
+
+#ifdef HAVE_PAM
+int pam_conv_callback(int num_msg, const struct pam_message **msg,
+        struct pam_response **resp, void *appdata_ptr __attribute__((__unused__)))
+{
+    int i;
+    struct pam_response *resp_array =
+        calloc(sizeof(struct pam_response), num_msg);
+
+    if (resp_array == NULL)
+        return PAM_BUF_ERR;
+
+    for (i=0; i<num_msg; i++) {
+        if (msg[i]->msg_style == PAM_ERROR_MSG)
+            fprintf(stderr, "%s", msg[i]->msg);
+        if (msg[i]->msg_style == PAM_PROMPT_ECHO_OFF ||
+                msg[i]->msg_style == PAM_PROMPT_ECHO_ON) {
+            resp_array[i].resp = strdup("");
+            resp_array[i].resp_retcode = 0;
+        }
+    }
+    *resp = resp_array;
+    return PAM_SUCCESS;
+}
+
+static struct pam_conv conv = {
+    pam_conv_callback,
+    NULL
+};
+
+/* Start process as given user, register session with PAM (and logind via
+ * pam_systemd) first; wait for the process to terminate.
+ */
+pid_t do_execute(char *user, char *path, char **argv)
+{
+    char *tty = NULL;
+    struct passwd *pw;
+    struct passwd pw_copy;
+    int retval=0, status;
+    char **env;
+    char env_buf[256];
+    pam_handle_t *pamh=NULL;
+    pid_t pid;
+
+    if (!user)
+        goto error;
+
+    pw = getpwnam (user);
+    if (! (pw && pw->pw_name && pw->pw_name[0] && pw->pw_dir && pw->pw_dir[0]
+                && pw->pw_passwd)) {
+        fprintf(stderr, "user %s does not exist", user);
+        goto error;
+    }
+
+    /* Make a copy of the password information and point pw at the local
+     * copy instead.  Otherwise, some systems (e.g. Linux) would clobber
+     * the static data through the getlogin call.
+     */
+    pw_copy = *pw;
+    pw = &pw_copy;
+    pw->pw_name = strdup(pw->pw_name);
+    pw->pw_passwd = strdup(pw->pw_passwd);
+    pw->pw_dir = strdup(pw->pw_dir);
+    pw->pw_shell = strdup(pw->pw_shell);
+    endpwent();
+
+    retval = pam_start("qubes-gui-agent", user, &conv, &pamh);
+    if (retval != PAM_SUCCESS)
+        goto error;
+
+    /* provide env variables to PAM and the X session */
+    snprintf(env_buf, sizeof(env_buf), "HOME=%s", pw->pw_dir);
+    retval = pam_putenv(pamh, env_buf);
+    if (retval != PAM_SUCCESS)
+        goto error;
+    snprintf(env_buf, sizeof(env_buf), "SHELL=%s", pw->pw_shell);
+    retval = pam_putenv(pamh, env_buf);
+    if (retval != PAM_SUCCESS)
+        goto error;
+    snprintf(env_buf, sizeof(env_buf), "USER=%s", pw->pw_name);
+    retval = pam_putenv(pamh, env_buf);
+    if (retval != PAM_SUCCESS)
+        goto error;
+    snprintf(env_buf, sizeof(env_buf), "LOGNAME=%s", pw->pw_name);
+    retval = pam_putenv(pamh, env_buf);
+    if (retval != PAM_SUCCESS)
+        goto error;
+    if (getenv("ENV_PATH"))
+        snprintf(env_buf, sizeof(env_buf), "PATH=%s", getenv("ENV_PATH"));
+    else if (getenv("PATH"))
+        snprintf(env_buf, sizeof(env_buf), "PATH=%s", getenv("PATH"));
+    else
+        snprintf(env_buf, sizeof(env_buf), "PATH=%s", "/usr/local/bin:/usr/bin:/bin");
+    retval = pam_putenv(pamh, env_buf);
+    if (retval != PAM_SUCCESS)
+        goto error;
+
+    if (getenv("XDG_SEAT")) {
+        snprintf(env_buf, sizeof(env_buf), "XDG_SEAT=%s", getenv("XDG_SEAT"));
+        retval = pam_putenv(pamh, env_buf);
+        if (retval != PAM_SUCCESS)
+            goto error;
+    }
+    if (getenv("XDG_SESSION_CLASS")) {
+        snprintf(env_buf, sizeof(env_buf), "XDG_SESSION_CLASS=%s",
+                getenv("XDG_SESSION_CLASS"));
+        retval = pam_putenv(pamh, env_buf);
+        if (retval != PAM_SUCCESS)
+            goto error;
+    }
+    if (getenv("DISPLAY")) {
+        retval = pam_set_item(pamh, PAM_XDISPLAY, getenv("DISPLAY"));
+        if (retval != PAM_SUCCESS)
+            goto error;
+    }
+    if (isatty(0) && (tty=ttyname(0))) {
+        retval = pam_set_item(pamh, PAM_TTY, tty);
+        if (retval != PAM_SUCCESS)
+            goto error;
+        if (strncmp(tty, "/dev/tty", 8) == 0) {
+            snprintf(env_buf, sizeof(env_buf), "XDG_VTNR=%s", tty+8);
+            retval = pam_putenv(pamh, env_buf);
+            if (retval != PAM_SUCCESS)
+                goto error;
+        }
+    }
+
+    /* authenticate */
+    retval = pam_authenticate(pamh, 0);
+    if (retval != PAM_SUCCESS)
+        goto error;
+
+    retval = initgroups(pw->pw_name, pw->pw_gid);
+    if (retval == -1) {
+        perror("initgroups");
+        goto error;
+    }
+
+    retval = pam_setcred(pamh, PAM_ESTABLISH_CRED);
+    if (retval != PAM_SUCCESS)
+        goto error;
+
+    /* open session */
+    retval = pam_open_session(pamh, 0);
+    if (retval != PAM_SUCCESS)
+        goto error;
+
+    pid = fork();
+
+    switch (pid) {
+        case -1:
+            perror("fork xorg");
+            goto error;
+        case 0:
+            /* child */
+
+            if (setgid (pw->pw_gid))
+                exit(126);
+            if (setuid (pw->pw_uid))
+                exit(126);
+            setsid();
+
+            /* This is a copy but don't care to free as we exec later anyway.  */
+            env = pam_getenvlist (pamh);
+
+            /* try to enter home dir, but don't abort if it fails */
+            retval = chdir(pw->pw_dir);
+            if (retval == -1)
+                warn("chdir(%s)", pw->pw_dir);
+
+            execve(path, argv, env);
+            perror("execve cmd");
+            exit(127);
+        default:;
+    }
+
+    child_pid = pid;
+
+    for (;;) {
+        pid_t wait_pid = waitpid(pid, &status, 0);
+        if (wait_pid == (pid_t)-1) {
+            if (errno == EINTR)
+                continue;
+            perror("waitpid");
+            goto error;
+        }
+        if (wait_pid == pid)
+            break;
+    }
+
+    child_pid = 0;
+
+    retval = pam_close_session(pamh, 0);
+    retval = pam_setcred(pamh, PAM_DELETE_CRED | PAM_SILENT);
+    pam_end(pamh, retval);
+
+    if (WIFSIGNALED(status))
+        return 128+WTERMSIG(status);
+    else
+        return WEXITSTATUS(status);
+error:
+    if (pamh)
+        pam_end(pamh, retval);
+    return -1;
+}
+
+#else
+/* in no-PAM case, simply switch to the target user and exec in place - there
+ * is no need to keep parent process running as there nothing to cleanup
+ */
+pid_t do_execute(char *user, char *path, char **argv)
+{
+    pid_t pid;
+    int retval;
+    struct passwd *pw;
+
+    pw = getpwnam (user);
+    if (! (pw && pw->pw_name && pw->pw_name[0] && pw->pw_dir && pw->pw_dir[0]
+                && pw->pw_passwd)) {
+        fprintf(stderr, "user %s does not exist", user);
+        goto error;
+    }
+
+    if (setenv("HOME", pw->pw_dir, 1))
+        goto error;
+    if (setenv("SHELL", pw->pw_shell, 1))
+        goto error;
+    if (setenv("USER", pw->pw_name, 1))
+        goto error;
+    if (setenv("LOGNAME", pw->pw_name, 1))
+        goto error;
+
+    retval = initgroups(pw->pw_name, pw->pw_gid);
+    if (retval == -1) {
+        perror("initgroups");
+        goto error;
+    }
+
+    if (setgid (pw->pw_gid))
+        exit(126);
+    if (setuid (pw->pw_uid))
+        exit(126);
+    setsid();
+
+    /* try to enter home dir, but don't abort if it fails */
+    retval = chdir(pw->pw_dir);
+    if (retval == -1)
+        warn("chdir(%s)", pw->pw_dir);
+
+    execve(path, argv, env);
+    perror("execve cmd");
+    return -1;
+}
+#endif
+
+void propagate_signal(int signal) {
+    if (child_pid)
+        kill(child_pid, signal);
+}
+
+void usage(char *argv0) {
+    fprintf(stderr, "Usage: %s user path arg0 [args ...]\n", argv0);
+    fprintf(stderr, "Run a process from *path* with *arg0*, *args*, as user *user*\n");
+#ifdef HAVE_PAM
+    fprintf(stderr, "The user session will be registered in pam/logind as graphical one\n");
+    fprintf(stderr, "This require the following environment variables to be set:\n");
+    fprintf(stderr, " - XDG_SEAT\n");
+    fprintf(stderr, " - XDG_SESSION_CLASS\n");
+    fprintf(stderr, " - DISPLAY\n");
+    fprintf(stderr, "Additionally, stdin needs to be connected to a tty. "
+            "XDG_VTNR is set based on it\n");
+#endif
+}
+
+int main(int argc, char **argv) {
+    if (argc < 4) {
+        usage(argv[0]);
+        exit(1);
+    }
+
+    signal(SIGTERM, propagate_signal);
+    signal(SIGHUP, propagate_signal);
+
+    return do_execute(argv[1], argv[2], argv+3);
+}

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -46,6 +46,7 @@ BuildRequires:	libXt-devel
 BuildRequires:	libtool-ltdl-devel
 BuildRequires:	pulseaudio-libs-devel >= 0.9.21, pulseaudio-libs-devel <= 12.2
 BuildRequires:	xorg-x11-server-devel
+BuildRequires:	pam-devel
 BuildRequires:	qubes-libvchan-@BACKEND_VMM@-devel
 BuildRequires:	qubes-gui-common-devel >= 3.2.0
 BuildRequires:	qubes-db-devel
@@ -135,6 +136,7 @@ rm -f %{name}-%{version}
 %files
 %defattr(-,root,root,-)
 /usr/bin/qubes-gui
+/usr/bin/qubes-gui-runuser
 /usr/bin/qubes-session
 /usr/bin/qubes-run-xorg
 /usr/bin/qubes-change-keyboard-layout
@@ -146,6 +148,7 @@ rm -f %{name}-%{version}
 /etc/profile.d/qubes-gui.sh
 /etc/profile.d/qubes-gui.csh
 /etc/profile.d/qubes-session.sh
+%config /etc/pam.d/qubes-gui-agent
 %config /etc/security/limits.d/90-qubes-gui.conf
 %config /etc/xdg/Trolltech.conf
 /etc/X11/xinit/xinitrc.d/qubes-keymap.sh
@@ -156,6 +159,7 @@ rm -f %{name}-%{version}
 %config /etc/sysconfig/desktop
 /etc/sysconfig/modules/qubes-u2mfn.modules
 /lib/systemd/system/qubes-gui-agent.service
+/lib/udev/rules.d/70-master-of-seat.rules
 /usr/lib/modules-load.d/qubes-gui.conf
 /usr/lib/tmpfiles.d/qubes-session.conf
 /usr/lib/sysctl.d/30-qubes-gui-agent.conf


### PR DESCRIPTION
Most of the logind session registration is done by pam_systemd, but it
needs some extra data to properly register X11 session. Most of it can be
set using environment variables (XDG_SEAT, XDG_VTNR, XDG_SESSION_CLASS).
But at least DISPLAY cannot, it needs to be set with pam_set_item(3).
Unfortunately standard utilities like su or runuser don't do that, which
means we need our own wrapper for that.

Add qubes-gui-runuser, similar to runuser. The main difference is setting
everything needed for logind to recognize the session as graphical -
including PAM_XDISPLAY and use that instead of su. Note that the
qubes-run-xorg script is called as root, so the qubes-gui-runuser does not
need to have suid.

In addition to that, logind require seat to have at least one device with
master-of-seat tag, to consider the seat graphical. VMs have not so much
devices (especially PV or PVH), but each have pcspkr, which apparently is
an input device. Tag it with master-of-seat and attach to seat0 to satisfy
logind requirements.

The last thing is binding X session to a tty. Do that by launching
qubes-gui-agent service connected to tty7, and XDG_VTNR based on control
tty name in qubes-gui-runuser. This require stdin not being closed when
starting qubes-run-xorg.

Fixes QubesOS/qubes-issues#3664

While at it, include also few other fixes/cleanups.