### PR TITLE
Invoke the xsession scripts with bash so that .bash_profile etc are loaded

### DIFF
--- a/appvm-scripts/usrbin/qubes-run-xorg
+++ b/appvm-scripts/usrbin/qubes-run-xorg
@@ -96,4 +96,4 @@ fi
 # Use sh -l here to load all session startup scripts (/etc/profile, ~/.profile
 # etc) to populate environment. This is the environment that will be used for
 # all user applications and qrexec calls.
-exec /usr/bin/qubes-gui-runuser "$DEFAULT_USER" /bin/sh -l -c "exec /usr/bin/xinit $XSESSION -- $XORG :0 -nolisten tcp vt07 -wr -config xorg-qubes.conf > ~/.xsession-errors 2>&1"
+exec /usr/bin/qubes-gui-runuser "$DEFAULT_USER" /bin/bash -l -c "exec /usr/bin/xinit $XSESSION -- $XORG :0 -nolisten tcp vt07 -wr -config xorg-qubes.conf > ~/.xsession-errors 2>&1"


### PR DESCRIPTION
This merge https://github.com/QubesOS/qubes-gui-agent-linux/commit/130865253fe03d37cdec17c8fabdae6bbcca1354 changed the way xinit is executed. It now invokes `/bin/sh`, which on Debian is 'dash' and not 'bash'.

The unforeseen effect is that config files like `.bash_profile` are not actually loaded when these X session startup scripts are run at boot.

As one example of this impact, `QUBES_GPG_AUTOACCEPT` user overrides in a GPG vault VM are not respected, because `.bash_profile` is ignored.

On Fedora it was probably unaffected since `/bin/sh` is still bash.

This commit forces `/bin/bash` which fixes QUBES_GPG_AUTOACCEPT (and potentially other things) for me.