### PR TITLE
Disable "transparent hugepage" kernel feature

### DIFF
--- a/appvm-scripts/qubes-gui-agent.service
+++ b/appvm-scripts/qubes-gui-agent.service
@@ -10,6 +10,9 @@ TTYPath=/dev/tty7
 #Environment=ENV_PATH=/usr/local/bin:/usr/bin:/bin
 # pretend tha user is at local console
 ExecStartPre=/bin/mkdir -p /var/run/console ; /bin/touch /var/run/console/user
+# Disable "transparent hugepage" feature, as it's incompatible with u2mfn module.
+# See QubesOS/qubes-issues#5212 for details
+ExecStartPre=/bin/sh -c 'p=/sys/kernel/mm/transparent_hugepage/enabled; fgrep -q [always] $p && echo madvise > $p; true'
 ExecStart=/usr/bin/qubes-gui $GUI_OPTS
 # clean env
 ExecStopPost=/bin/rm -f /tmp/qubes-session-env /tmp/qubes-session-waiter


### PR DESCRIPTION
Kernel in Debian has this set to "always" by default, which breaks u2mfn
module. Specifically, it tries to get address of an arbitrary memory
page mapped by X server, and it fails if it's merged into huge page.
u2mfn module is gone in the next Qubes release, so as a temporary
measure revert transparent hugepage to "madvise".

Do that only if it was set to "always". This will prevent overriding
other user choices.

QubesOS/qubes-issues#5212