### PR TITLE
Archlinux: Allow any pulseaudio version between 13.0 and 14.0

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -71,7 +71,7 @@ package_qubes-vm-pulseaudio() {
 
 pkgdesc="Pulseaudio support for Qubes VM"
 depends=( 'alsa-lib' 'alsa-utils' 'pulseaudio-alsa'
-		'pulseaudio>=12.0' 'pulseaudio<12.3'
+		'pulseaudio>=13.0' 'pulseaudio<14.0'
 )
 install=PKGBUILD-pulseaudio.install
 pa_ver=`(pkg-config --modversion libpulse 2>/dev/null || echo 0.0) | cut -f 1 -d "-"`


### PR DESCRIPTION
 for qubes-vm-pulseaudio