### PR TITLE
Allow GUI and AUDIO client to be ran before their corresonding servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,8 @@ endif
 		$(DESTDIR)/usr/lib/sysctl.d/30-qubes-gui-agent.conf
 	install -D -m 0644 appvm-scripts/lib/udev/rules.d/70-master-of-seat.rules \
 		$(DESTDIR)/$(SYSLIBDIR)/udev/rules.d/70-master-of-seat.rules
+	install -D appvm-scripts/usr/lib/qubes/qubes-gui-agent-pre.sh \
+		$(DESTDIR)/usr/lib/qubes/qubes-gui-agent-pre.sh
 ifeq ($(shell lsb_release -is), Debian)
 	install -D -m 0644 appvm-scripts/etc/pam.d/qubes-gui-agent.debian \
 		$(DESTDIR)/etc/pam.d/qubes-gui-agent

--- a/appvm-scripts/qubes-gui-agent.service
+++ b/appvm-scripts/qubes-gui-agent.service
@@ -8,9 +8,7 @@ TTYPath=/dev/tty7
 # custom PATH for X session can be set with ENV_PATH; otherwise service's PATH
 # is inherited
 #Environment=ENV_PATH=/usr/local/bin:/usr/bin:/bin
-# pretend tha user is at local console
-ExecStartPre=/bin/mkdir -p /var/run/console ; /bin/touch /var/run/console/user
-ExecStartPre=/bin/sh -c ". /usr/lib/qubes/init/functions; if qsvc guivm-gui-agent; then sed -i '/DISPLAY=/d' /var/run/qubes-service-environment; echo DISPLAY=:1 >> /var/run/qubes-service-environment; fi;"
+ExecStartPre=/bin/sh -c /usr/lib/qubes/qubes-gui-agent-pre.sh
 ExecStart=/usr/bin/qubes-gui $GUI_OPTS
 # clean env
 ExecStopPost=/bin/rm -f /tmp/qubes-session-env /tmp/qubes-session-waiter

--- a/appvm-scripts/usr/lib/qubes/qubes-gui-agent-pre.sh
+++ b/appvm-scripts/usr/lib/qubes/qubes-gui-agent-pre.sh
@@ -11,13 +11,12 @@ if qsvc guivm-gui-agent; then
     echo DISPLAY=:1 >> /var/run/qubes-service-environment
 fi
 
-while [ -z "$(qubesdb-read /qubes-gui-domain-xid > /dev/null 2>&1)" ];
-do
-    sleep 1
-done
-
 # set gui opts
-gui_opts="-d $(qubesdb-read /qubes-gui-domain-xid)"
+gui_xid="$(qubesdb-read -w /qubes-gui-domain-xid)"
+if [ -z "$gui_xid" ]; then
+    gui_xid=0
+fi
+gui_opts="-d $gui_xid"
 
 debug_mode=$(qubesdb-read /qubes-debug-mode 2> /dev/null)
 if [ -n "$debug_mode" ] && [ "$debug_mode" -gt 0 ]; then

--- a/appvm-scripts/usr/lib/qubes/qubes-gui-agent-pre.sh
+++ b/appvm-scripts/usr/lib/qubes/qubes-gui-agent-pre.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+. /usr/lib/qubes/init/functions
+
+# pretend tha user is at local console
+mkdir -p /var/run/console ; /bin/touch /var/run/console/user
+
+# set corresponding display for guivm
+if qsvc guivm-gui-agent; then
+    sed -i '/DISPLAY=/d' /var/run/qubes-service-environment
+    echo DISPLAY=:1 >> /var/run/qubes-service-environment
+fi
+
+while [ -z "$(qubesdb-read /qubes-gui-domain-xid > /dev/null 2>&1)" ];
+do
+    sleep 1
+done
+
+# set gui opts
+gui_opts="-d $(qubesdb-read /qubes-gui-domain-xid)"
+
+debug_mode=$(qubesdb-read /qubes-debug-mode 2> /dev/null)
+if [ -n "$debug_mode" ] && [ "$debug_mode" -gt 0 ]; then
+    gui_opts="$gui_opts -vv"
+fi
+
+echo "GUI_OPTS=$gui_opts" >> /var/run/qubes-service-environment

--- a/debian/qubes-gui-agent.install
+++ b/debian/qubes-gui-agent.install
@@ -22,5 +22,6 @@ usr/bin/qubes-set-monitor-layout
 usr/lib/qubes/icon-sender
 usr/lib/sysctl.d/30-qubes-gui-agent.conf
 usr/lib/tmpfiles.d/*
+usr/lib/qubes/qubes-gui-agent-pre.sh
 usr/share/glib-2.0/schemas/20_qubes-gui-vm.gschema.override
 var/log/qubes

--- a/pulse/start-pulseaudio-with-vchan
+++ b/pulse/start-pulseaudio-with-vchan
@@ -27,9 +27,7 @@ if [ -f /etc/this-is-dvm ]; then
   qubesdb-watch /qubes-restore-complete
 fi
 
-while [ -z "$(qubesdb-read /qubes-audio-domain-xid >/dev/null 2>&1)" ]; do
-  sleep 1
-done
+qubesdb-read -w /qubes-audio-domain-xid >/dev/null
 
 pulseaudio --start \
   -n --file=/etc/pulse/qubes-default.pa \

--- a/pulse/start-pulseaudio-with-vchan
+++ b/pulse/start-pulseaudio-with-vchan
@@ -20,12 +20,17 @@
 #
 #
 
-type pulseaudio >/dev/null 2> /dev/null || exit 0
+type pulseaudio >/dev/null 2>&1 || exit 0
 
 if [ -f /etc/this-is-dvm ]; then
-    # ... wait for Dom0 notify
-    qubesdb-watch /qubes-restore-complete
+  # ... wait for Dom0 notify
+  qubesdb-watch /qubes-restore-complete
 fi
+
+while [ -z "$(qubesdb-read /qubes-audio-domain-xid >/dev/null 2>&1)" ]; do
+  sleep 1
+done
+
 pulseaudio --start \
-    -n --file=/etc/pulse/qubes-default.pa \
-	--exit-idle-time=-1
+  -n --file=/etc/pulse/qubes-default.pa \
+  --exit-idle-time=-1

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -170,6 +170,7 @@ rm -f %{name}-%{version}
 /lib/udev/rules.d/70-master-of-seat.rules
 /usr/lib/tmpfiles.d/qubes-session.conf
 /usr/lib/sysctl.d/30-qubes-gui-agent.conf
+/usr/lib/qubes/qubes-gui-agent-pre.sh
 %{_datadir}/glib-2.0/schemas/20_qubes-gui-vm.gschema.override
 /usr/lib/qubes/icon-sender
 /etc/xdg/autostart/qubes-icon-sender.desktop


### PR DESCRIPTION
- gui-agent: put ExecPre in separate script
https://github.com/QubesOS/qubes-issues/issues/5662
https://github.com/QubesOS/qubes-issues/issues/833
https://github.com/QubesOS/qubes-issues/issues/1590