### PR TITLE
vmside: update cursor position on LeaveNotify

### DIFF
--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -1551,6 +1551,10 @@ void handle_crossing(Ghandles * g, XID winid)
         XID window_under_pointer, root_returned;
         int root_x, root_y, win_x, win_y;
         unsigned int mask_return;
+
+        // move pointer out of window
+        feed_xdriver(g, 'M', attr.x + key.x, attr.y + key.y);
+
         ret =
             XQueryPointer(g->display, g->root_win, &root_returned,
                     &window_under_pointer, &root_x, &root_y,


### PR DESCRIPTION
When moving mouse through the window edge, the LeaveNotify event
contains cursor coordinates that are outside of window bounds.
Forward them to local window, otherwise the last event position
the window will receive will be from a MotionNotify still inside
the window.

This fixes an annoying glitch in Firefox: moving mouse cursor up
from a tab title (which touches the top edge of the window) makes
Firefox think we are still hovering over the tab, and displays a
tooltip, which stays there even after you switch to a different
program.