### PR TITLE
Bump ICON_MAX_SIZE

### DIFF
--- a/window-icon-updater/icon-sender
+++ b/window-icon-updater/icon-sender
@@ -32,7 +32,7 @@ from xcffib import xproto
 import sys
 import struct
 
-ICON_MAX_SIZE = 128
+ICON_MAX_SIZE = 256
 
 
 class NoIconError(KeyError):


### PR DESCRIPTION
Chromium uses 256x256 icons.

Needs fix to Python library on the receiving side:
QubesOS/qubes-linux-utils#54