### PR TITLE
Do not run X server on sys-gui-gpu

### DIFF
--- a/appvm-scripts/qubes-gui-agent.service
+++ b/appvm-scripts/qubes-gui-agent.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Qubes GUI Agent
 After=qubes-meminfo-writer.service qubes-mount-dirs.service
+ConditionPathExists=!/var/run/qubes-service/lightdm
 
 [Service]
 StandardInput=tty


### PR DESCRIPTION
On sys-gui-gpu we use lightdm for running X server, but we still need
guivm-gui-agent service

Part of: QubesOS/qubes-issues#2618