### PR TITLE
archlinux: set dependencies on xorg server ABI version instead of server

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -50,7 +50,12 @@ make appvm
 
 package_qubes-vm-gui() {
 
-depends=('xorg-xinit' 'libxcomposite' 'zenity' 'qubes-libvchan-xen' 'python-xcffib' 'xorg-server>=1.20' 'xorg-server<1.21')
+depends=('xorg-xinit' 'libxcomposite' 'zenity' 'qubes-libvchan-xen' 'python-xcffib'
+			# Xorg dependencies are on specific ABI versions: https://www.x.org/wiki/XorgModuleABIVersions/
+			# These can also be verified with pacman -Qi xorg-server (Provides)
+			# There is however a discrepency if verifying via pkg-config --variable abi_videodrv xorg-server
+			'X-ABI-VIDEODRV_VERSION=24.0' 'X-ABI-XINPUT_VERSION=24.1' 'X-ABI-EXTENSION_VERSION=10.0'
+			)
 install=PKGBUILD.install
 
 make install-rh-agent DESTDIR=$pkgdir LIBDIR=/usr/lib USRLIBDIR=/usr/lib SYSLIBDIR=/usr/lib


### PR DESCRIPTION
Following suggestion here: https://github.com/QubesOS/qubes-issues/issues/3908#issuecomment-563715196
Tracking issue: https://github.com/QubesOS/qubes-issues/issues/3908

I followed @marmarek proposal from last year (sorry for getting there only now) to update archlinux package based on ABI version instead of xorg-server version.
I'm not sure however if we need to check all the ABI versions for XEXTENSION, XINPUT and XVIDEO. I put all of them as dependency in the commit above.