### PR TITLE
Extract Xephyr to a separate script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,8 @@ install-common:
 		$(DESTDIR)/usr/bin/qubes-run-xorg
 	install -D appvm-scripts/usrbin/qubes-run-xephyr \
 		$(DESTDIR)/usr/bin/qubes-run-xephyr
+	install -D appvm-scripts/usrbin/qubes-start-xephyr \
+		$(DESTDIR)/usr/bin/qubes-start-xephyr
 	install -D appvm-scripts/usrbin/qubes-change-keyboard-layout \
 		$(DESTDIR)/usr/bin/qubes-change-keyboard-layout
 	install -D appvm-scripts/usrbin/qubes-set-monitor-layout \
@@ -170,6 +172,8 @@ endif
 	install -d $(DESTDIR)/etc/qubes-rpc
 	ln -s ../../usr/bin/qubes-set-monitor-layout \
 		$(DESTDIR)/etc/qubes-rpc/qubes.SetMonitorLayout
+	ln -s ../../usr/bin/qubes-start-xephyr \
+		$(DESTDIR)/etc/qubes-rpc/qubes.GuiVMSession
 	install -D window-icon-updater/icon-sender \
 		$(DESTDIR)/usr/lib/qubes/icon-sender
 	install -m 0644 -D window-icon-updater/qubes-icon-sender.desktop \

--- a/appvm-scripts/usrbin/qubes-run-xorg
+++ b/appvm-scripts/usrbin/qubes-run-xorg
@@ -109,15 +109,8 @@ if qsvc guivm-gui-agent; then
     DISPLAY_XORG=:1
     DISPLAY_XEPHYR=:0
 
-    # Create Xorg and Xephyr server (emulated GPU passthrough)
-    runuser -u "$DEFAULT_USER" -- /bin/sh -l -c "exec $XORG $DISPLAY_XORG -terminate -nolisten tcp vt07 -wr -config xorg-qubes.conf > ~/.xorg-errors 2>&1" &
-    # Wait Xorg display available
-    while ! xdpyinfo -display $DISPLAY_XORG > /dev/null 2>&1
-    do
-        sleep 1
-    done
-    # Run xsession into Xephyr
-    /usr/bin/qubes-gui-runuser "$DEFAULT_USER" /bin/sh -l -c "DISPLAY=$DISPLAY_XORG /usr/bin/xinit $XSESSION -- /usr/bin/qubes-run-xephyr $DISPLAY_XEPHYR > ~/.xsession-errors 2>&1"
+    # Create Xorg. Xephyr will be started using qubes-start-xephyr later.
+    exec runuser -u "$DEFAULT_USER" -- /bin/sh -l -c "exec $XORG $DISPLAY_XORG -nolisten tcp vt07 -wr -config xorg-qubes.conf > ~/.xorg-errors 2>&1" &
 else
     # Use sh -l here to load all session startup scripts (/etc/profile, ~/.profile
     # etc) to populate environment. This is the environment that will be used for

--- a/appvm-scripts/usrbin/qubes-start-xephyr
+++ b/appvm-scripts/usrbin/qubes-start-xephyr
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+if [ $(whoami) == "root" ]; then
+    echo "Should be run as normal user!"
+    exit 1
+fi
+
+DISPLAY_XORG=:1
+DISPLAY_XEPHYR=:0
+
+XSESSION="/etc/X11/xinit/xinitrc"
+if [ -f /etc/X11/Xsession ]; then
+    # Debian-based distro, set Xsession appropriately
+    XSESSION="/etc/X11/Xsession qubes-session"
+fi
+
+# Wait for Xorg display (started by qubes-run-xorg)
+if ! timeout 30s sh -c "while ! xdpyinfo -display $DISPLAY_XORG > /dev/null 2>&1; do sleep 1; done"; then
+    echo "Timed out waiting for Xorg display $DISPLAY_XORG"
+    exit 1
+fi
+
+# Run xsession into Xephyr
+export DISPLAY=$DISPLAY_XORG
+exec /usr/bin/xinit $XSESSION -- /usr/bin/qubes-run-xephyr $DISPLAY_XEPHYR > ~/.xsession-errors 2>&1

--- a/appvm-scripts/usrbin/qubes-start-xephyr
+++ b/appvm-scripts/usrbin/qubes-start-xephyr
@@ -5,6 +5,15 @@ if [ $(whoami) == "root" ]; then
     exit 1
 fi
 
+# do not let child processes believe they are running as qrexec service
+# directly
+unset QREXEC_REMOTE_DOMAIN
+unset QREXEC_SERVICE_FULL_NAME
+unset QREXEC_SERVICE_ARGUMENT
+unset QREXEC_REQUESTED_TARGET
+unset QREXEC_REQUESTED_TARGET_TYPE
+unset QREXEC_AGENT_PID
+
 DISPLAY_XORG=:1
 DISPLAY_XEPHYR=:0
 

--- a/debian/qubes-gui-agent.install
+++ b/debian/qubes-gui-agent.install
@@ -9,6 +9,7 @@ etc/profile.d/qubes-session.sh
 etc/pam.d/qubes-gui-agent
 etc/security/limits.d/90-qubes-gui.conf
 etc/qubes-rpc/qubes.SetMonitorLayout
+etc/qubes-rpc/qubes.GuiVMSession
 etc/qubes/post-install.d/20-qubes-guivm-gui-agent.sh
 etc/xdg/autostart/qubes-icon-sender.desktop
 etc/xdg/autostart/qubes-qrexec-fork-server.desktop
@@ -24,6 +25,7 @@ usr/bin/qubes-gui
 usr/bin/qubes-gui-runuser
 usr/bin/qubes-run-xorg
 usr/bin/qubes-run-xephyr
+usr/bin/qubes-start-xephyr
 usr/bin/qubes-session
 usr/bin/qubes-set-monitor-layout
 usr/lib/qubes/icon-sender

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -152,6 +152,7 @@ rm -f %{name}-%{version}
 /usr/bin/qubes-session
 /usr/bin/qubes-run-xorg
 /usr/bin/qubes-run-xephyr
+/usr/bin/qubes-start-xephyr
 /usr/bin/qubes-change-keyboard-layout
 /usr/bin/qubes-set-monitor-layout
 %{_libdir}/xorg/modules/drivers/qubes_drv.so
@@ -168,6 +169,7 @@ rm -f %{name}-%{version}
 /etc/X11/xinit/xinitrc.d/20qt-gnome-desktop-session-id.sh
 /etc/X11/xinit/xinitrc.d/50guivm-windows-prefix.sh
 /etc/qubes-rpc/qubes.SetMonitorLayout
+/etc/qubes-rpc/qubes.GuiVMSession
 /etc/qubes/post-install.d/20-qubes-guivm-gui-agent.sh
 %config /etc/sysconfig/desktop
 /lib/systemd/system/qubes-gui-agent.service


### PR DESCRIPTION
qubes-run-xorg will only start the "outer" Xorg instance. The
Xephyr session should be initiated using qrexec:

    qvm-run -p --no-gui --service $GUIVM qubes.GuiVMSession

The '-p' ensures that the above command will wait for the session
to finish.