### PR TITLE
Increase maxclock to support high refreshrate

### DIFF
--- a/xf86-video-dummy/src/dummy_driver.c
+++ b/xf86-video-dummy/src/dummy_driver.c
@@ -556,7 +556,7 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
     ClockRangePtr clockRanges;
     int i;
     DUMMYPtr dPtr;
-    int maxClock = 300000;
+    int maxClock = 1000000;
     GDevPtr device = xf86GetEntityInfo(pScrn->entityList[0])->device;
 
     if (flags & PROBE_DETECT) 


### PR DESCRIPTION
Increase maxclock so that high resolution monitors can have higher refresh rates. This will be a potential fix for issue #3175