### PR TITLE
Start gui-agent only after systemd let in normal users

### DIFF
--- a/appvm-scripts/qubes-gui-agent.service
+++ b/appvm-scripts/qubes-gui-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Qubes GUI Agent
-After=qubes-meminfo-writer.service qubes-mount-dirs.service
+After=systemd-user-sessions.service
 ConditionPathExists=!/var/run/qubes-service/lightdm
 
 [Service]


### PR DESCRIPTION
Use After=systemd-user-sessions.service
This way, we can be sure to start user applications (including those
from /etc/xdg/autostart) only when they are supposed to be started.
Other system services may order themselves before
systemd-user-session.service (or any of related .target unit).