### PR TITLE
(release4.0) vmside: fix strncat() buffer overflow in getwmname_tochar()

### DIFF
--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -394,7 +394,7 @@ int getwmname_tochar(Ghandles * g, XID window, char *outbuf, int bufsize)
         XFree(text_prop_return.value);
         return 0;
     }
-    strncat(outbuf, list[0], bufsize);
+    strncat(outbuf, list[0], bufsize - 1);
     XFree(text_prop_return.value);
     XFreeStringList(list);
     if (g->log_level > 0)


### PR DESCRIPTION
Don't write the terminating \0 past the buffer for WM_NAME >= 128 bytes.

Fixes QubesOS/qubes-issues#6444