### PR TITLE
rpm: add xrandr dependency

### DIFF
--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -71,6 +71,7 @@ Requires:   xmodmap
 Requires:   xev
 Requires:   xdpyinfo
 Requires:   xprop
+Requires:   xrandr
 
 Provides:   qubes-gui-vm = %{version}-%{release}
 Obsoletes:  qubes-gui-vm < 4.0.0


### PR DESCRIPTION
It used to be part of xorg-x11-server-utils

QubesOS/qubes-issues#6568