### PR TITLE
Always keep latin keyboard layout

### DIFF
--- a/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
+++ b/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
@@ -11,6 +11,10 @@ set_keyboard_layout() {
     KEYMAP_LAYOUT="$(echo "$KEYMAP"+ | cut -f 1 -d +)"
     KEYMAP_VARIANT="$(echo "$KEYMAP"+ | cut -f 2 -d +)"
     KEYMAP_OPTIONS="$(echo "$KEYMAP"+ | cut -f 3 -d +)"
+    if [ "$KEYMAP_LAYOUT" != "us" ]; then
+        KEYMAP_LAYOUT="$KEYMAP_LAYOUT,us"
+    fi
+
     if [ -n "$KEYMAP_VARIANT" ]; then
         KEYMAP_VARIANT="-variant $KEYMAP_VARIANT"
     fi


### PR DESCRIPTION
Setting only non-latin layout breaks hotkeys in various applications, so setup secondary 'us' to propagated from dom0.

Fixes https://github.com/QubesOS/qubes-issues/issues/5431
Fixes https://github.com/QubesOS/qubes-issues/issues/6690