### PR TITLE
Fix support for non-latin variants when we append the us layout

### DIFF
--- a/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
+++ b/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
@@ -13,6 +13,7 @@ set_keyboard_layout() {
     KEYMAP_OPTIONS="$(echo "$KEYMAP"+ | cut -f 3 -d +)"
     if [ "$KEYMAP_LAYOUT" != "us" ]; then
         KEYMAP_LAYOUT="$KEYMAP_LAYOUT,us"
+        KEYMAP_VARIANT="$KEYMAP_VARIANT,"
     fi
 
     if [ -n "$KEYMAP_VARIANT" ]; then


### PR DESCRIPTION
Hey, @marmarek and @jevank, I was super happy to see that https://github.com/QubesOS/qubes-issues/issues/6690 was fixed by https://github.com/QubesOS/qubes-gui-agent-linux/pull/139, and in a much simpler way than my original suggestion. Unfortunately, there is a bug in this fix when you have a non-standard `KEYMAP_VARIANT`. Right now, `qubes-keymap.sh` will execute this on my machine:
```sh
setxkbmap -display :0 -layout bg,us -variant phonetic -option grp:alt_shift_toggle
```
when the correct thing it should execute is this:
```
setxkbmap -display :0 -layout bg,us -variant phonetic, -option grp:alt_shift_toggle
```

Notice the comma after `phonetic` - it needs to be there when there are multiple layouts, even if the non-us layout is first, otherwise the `phonetic` variant to the `bg` layout is not applied. And if there are no variants, the comma doesn't seem to be a problem :man_shrugging: This is from the `setxkbmap` manpage:
> -variant name
>   Specifies which variant of the keyboard layout should be used to determine the components which make up the keyboard description. The -variant option may only be used once. Multiple variants can be specified as a comma-separated list and will be matched with the layouts specified with -layout.
