### PR TITLE
archlinux: update xorg-server X-ABI depends

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=(qubes-vm-gui qubes-vm-pulseaudio)
 pkgver=$(cat version)
-pkgrel=10
+pkgrel=11
 epoch=
 pkgdesc="The Qubes GUI Agent for AppVMs"
 arch=("x86_64")
@@ -54,7 +54,7 @@ depends=('xorg-xinit' 'libxcomposite' 'zenity' 'qubes-libvchan' 'python-xcffib'
 			# Xorg dependencies are on specific ABI versions: https://www.x.org/wiki/XorgModuleABIVersions/
 			# These can also be verified with pacman -Qi xorg-server (Provides)
 			# There is however a discrepency if verifying via pkg-config --variable abi_videodrv xorg-server
-			'X-ABI-VIDEODRV_VERSION=24.0' 'X-ABI-XINPUT_VERSION=24.1' 'X-ABI-EXTENSION_VERSION=10.0'
+			'X-ABI-VIDEODRV_VERSION=25.2' 'X-ABI-XINPUT_VERSION=24.4' 'X-ABI-EXTENSION_VERSION=10.0'
 			)
 install=PKGBUILD.install
 


### PR DESCRIPTION
Fixes [#qubes-issues/issues/7048](https://github.com/QubesOS/qubes-issues/issues/7048)

Updated deps to match https://archlinux.org/packages/extra/x86_64/xorg-server/