### PR TITLE
archlinux: add lsb-release into make dependencies

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -9,7 +9,7 @@ license=('GPL')
 groups=()
 makedepends=(pkg-config make gcc patch git automake autoconf libtool
 			'pulseaudio<=15.0'
-			xorg-server-devel xorg-util-macros libxcomposite libxt pixman
+			xorg-server-devel xorg-util-macros libxcomposite libxt pixman lsb-release
 			qubes-vm-gui-common qubes-libvchan qubes-db-vm
 			)
 checkdepends=()


### PR DESCRIPTION
For more info, please see:
- https://github.com/QubesOS/qubes-issues/issues/7048#issuecomment-991975536

This change should be also backported to Qubes v4.0.