### PR TITLE
dummyqbs: Add glamor acceleration

### DIFF
--- a/appvm-scripts/etc/X11/xorg-qubes.conf.template
+++ b/appvm-scripts/etc/X11/xorg-qubes.conf.template
@@ -1,5 +1,6 @@
 Section "Module"
         Load "fb"
+        Load "glamoregl"
 EndSection
 
 Section "ServerLayout"   
@@ -13,6 +14,8 @@ Section "Device"
         Driver      "dummyqbs"
         VideoRam %MEM%
         Option "GUIDomID" "%GUI_DOMID%"
+        # Render option requires to override default Intel device
+        # Option "Render" "/dev/dri/renderD128"
 EndSection
 
 Section "Monitor"

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Build-Depends:
     xutils-dev,
     libvchan-dev,
     libx11-dev,
+    libgbm-dev,
     libxcomposite-dev,
     libxdamage-dev,
     libxfixes-dev,

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -53,6 +53,7 @@ BuildRequires:	qubes-libvchan-devel
 BuildRequires:	qubes-gui-common-devel >= 4.1.0
 BuildRequires:	qubes-db-devel
 BuildRequires:	xen-devel
+BuildRequires: mesa-libgbm-devel
 Requires:	Xorg %(xserver-sdk-abi-requires ansic)
 Requires:	Xorg %(xserver-sdk-abi-requires videodrv)
 Requires:	libXfixes

--- a/xf86-video-dummy/src/Makefile.am
+++ b/xf86-video-dummy/src/Makefile.am
@@ -25,11 +25,11 @@
 # _ladir passes a dummy rpath to libtool so the thing will actually link
 # TODO: -nostdlib/-Bstatic/-lgcc platform magic, not installing the .a, etc.
 
-AM_CFLAGS = $(XORG_CFLAGS) $(PCIACCESS_CFLAGS)
+AM_CFLAGS = $(XORG_CFLAGS) $(PCIACCESS_CFLAGS) $(GBM_CFLAGS)
 
 dummyqbs_drv_la_LTLIBRARIES = dummyqbs_drv.la
 dummyqbs_drv_la_LDFLAGS = -module -avoid-version
-dummyqbs_drv_la_LIBADD = $(XORG_LIBS) -L../../xf86-qubes-common -lxf86-qubes-common
+dummyqbs_drv_la_LIBADD = $(XORG_LIBS) $(GBM_LIBS) -L../../xf86-qubes-common -lxf86-qubes-common
 dummyqbs_drv_ladir = @moduledir@/drivers
 
 dummyqbs_drv_la_SOURCES = \

--- a/xf86-video-dummy/src/dummy.h
+++ b/xf86-video-dummy/src/dummy.h
@@ -47,6 +47,9 @@ typedef struct _color
     int blue;
 } dummy_colors;
 
+struct gbm_device;
+struct gbm_bo;
+
 typedef struct dummyRec 
 {
     DGAModePtr		DGAModes;
@@ -60,6 +63,11 @@ typedef struct dummyRec
     CloseScreenProcPtr CloseScreen;
     xf86CursorInfoPtr CursorInfo;
     CreateScreenResourcesProcPtr CreateScreenResources;
+    /* DRI support */
+    int fd;
+    Bool glamor;
+    struct gbm_device *gbm;
+    struct gbm_bo *front_bo;
 
     Bool DummyHWCursorShown;
     int cursorX, cursorY;


### PR DESCRIPTION
This enables native OpenGL support if render device available
(Intel mediated with GVT-g or passed through).

Based on https://patchwork.freedesktop.org/patch/143119/