### PR TITLE
Make qubes-session inherit the systemd user session variables.

### DIFF
--- a/appvm-scripts/usrbin/qubes-session
+++ b/appvm-scripts/usrbin/qubes-session
@@ -27,6 +27,14 @@
 
 loginctl activate "$XDG_SESSION_ID"
 
+# Now import the environment from the systemd user session.
+# This is necessary to enable users to configure their
+# Qubes environment using the standard environment.d
+# facility.  Documentation for the facility is at:
+# https://www.freedesktop.org/software/systemd/man/environment.d.html
+eval `systemctl --user show-environment | sed 's/^/export /'`
+
+
 if qsvc guivm-gui-agent; then
     if [ -e "$HOME/.xinitrc" ]; then
         . "$HOME/.xinitrc"

--- a/appvm-scripts/usrbin/qubes-session
+++ b/appvm-scripts/usrbin/qubes-session
@@ -32,7 +32,7 @@ loginctl activate "$XDG_SESSION_ID"
 # Qubes environment using the standard environment.d
 # facility.  Documentation for the facility is at:
 # https://www.freedesktop.org/software/systemd/man/environment.d.html
-eval `systemctl --user show-environment | sed 's/^/export /'`
+eval $(systemctl --user show-environment | sed 's/^/export /')
 
 
 if qsvc guivm-gui-agent; then


### PR DESCRIPTION
The standard environment.d facility is currently not respected in Qubes OS 4.1.  This leads to inability to define environment variables when starting apps via qrexec¹.

This should be fixed.  Here is the fix — it is a fix that will not have any substantial performance impact (it runs *once*), and uses documented APIs to execute on the fix.  Furthermore, the fix enables packaged software to ship environment variables in `/usr/lib/environment.d` as per the standard, without which presumable at least some software will simply be broken.

¹ Technically there's `/etc/profile.d` but that's meant to be used for **shells**.  There is no guarantee that apps started via qrexec will inherit these variables, and that doesn't cover software packaging factory environment variable customization in `/usr/lib/environment.d`.