### PR TITLE
Handle mod keys correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,14 @@ tags
 deb/
 pkgs
 debian/changelog.*
+/PKGBUILD*
+/gui-agent/qubes-gui
+/gui-common/qubes-gui-runuser
+/pkg/
+*.tar.zst
+/src/
+/xf86-input-mfndev/compile
+/xf86-input-mfndev/config.h.in
+/xf86-input-mfndev/depcomp
+/xf86-input-mfndev/ltmain.sh
+/xf86-qubes-common/libxf86-qubes-common.so

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -1611,11 +1611,9 @@ static void handle_keypress(Ghandles * g, XID UNUSED(winid))
             fprintf(stderr, "failed to get modifier state\n");
         state.mods = key.state;
     }
-    if (!g->sync_all_modifiers) {
-        // ignore all but CapsLock
-        state.mods &= LockMask;
-        key.state &= LockMask;
-    }
+    // ignore all but CapsLock
+    state.mods &= LockMask;
+    key.state &= LockMask;
     if (state.mods != key.state) {
         XModifierKeymap *modmap;
         int mod_index;
@@ -1660,6 +1658,7 @@ static void handle_keypress(Ghandles * g, XID UNUSED(winid))
         }
     }
 
+    if (key.keycode == 66) return; // caplocks
     feed_xdriver(g, 'K', key.keycode, key.type == KeyPress ? 1 : 0);
 }
 


### PR DESCRIPTION
Need to first install https://github.com/QubesOS/qubes-gui-daemon/pull/98, otherwise mod keys may not work.

To fix:
- [ ] ~~set correct mode of focus events, since some applications like xfce4 terminal rely on that to ignore window manager hot keys (see https://stackoverflow.com/questions/15270420/why-xgrabkey-generates-extra-focus-out-and-focus-in-events)~~ not as important
- [x] ~~events arrive out-of-order.~~ No such bug found.
- [x] duplicate RawKeyPress & RawKeyRelease for every key. Probably keyboard driver issue. Fixed in `qubes-guid`.