### PR TITLE
get-latest-pulsecore.sh: ensure to use gpg for git tag

### DIFF
--- a/get-latest-pulsecore.sh
+++ b/get-latest-pulsecore.sh
@@ -44,7 +44,7 @@ if [ "${LATEST_QUBES_VERSION}" != "${LATEST_REPO_VERSION}" ] && [ ! -e "$LOCALDI
     done
 
     # Verify integrity
-    git tag -v "$(git describe)"
+    git -c gpg.program=gpg tag -v "$(git describe)"
 
     # remove unwanted files
     find "src/pulsecore" -type f ! -regex '.*\.h$' -exec rm -f {} \;


### PR DESCRIPTION
It prevents calling split-gpg when it is configured in git config.