### PR TITLE
Drop obsolete checks for disposable VM restore

### DIFF
--- a/pulse/start-pulseaudio-with-vchan
+++ b/pulse/start-pulseaudio-with-vchan
@@ -22,11 +22,6 @@
 
 type pulseaudio >/dev/null 2>&1 || exit 0
 
-if [ -f /etc/this-is-dvm ]; then
-  # ... wait for Dom0 notify
-  qubesdb-watch /qubes-restore-complete
-fi
-
 qubesdb-read -w /qubes-audio-domain-xid >/dev/null
 
 pulseaudio --start \


### PR DESCRIPTION
Disposable VMs are not implemented this way anymore.