### PR TITLE
Let systemd manage PulseAudio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ DATADIR ?= /usr/share
 PA_VER_FULL ?= $(shell pkg-config --modversion libpulse | cut -d "-" -f 1 || echo 0.0)
 PA_MODULE_DIR ?= $(shell pkg-config --variable=modlibexecdir libpulse)
 
+USER_DROPIN_DIR ?= /usr/lib/systemd/user
+
 help:
 	@echo "Qubes GUI main Makefile:" ;\
 	    echo; \
@@ -106,6 +108,11 @@ install-pulseaudio:
 		$(DESTDIR)/$(USRLIBDIR)/tmpfiles.d/qubes-pulseaudio.conf
 	install -m 0644 -D appvm-scripts/etc/xdgautostart/qubes-pulseaudio.desktop \
 		$(DESTDIR)/etc/xdg/autostart/qubes-pulseaudio.desktop
+	install -d $(DESTDIR)$(USER_DROPIN_DIR)/pulseaudio.service.d
+	install -m 0644 pulse/pulseaudio.service.d/*.conf \
+		$(DESTDIR)$(USER_DROPIN_DIR)/pulseaudio.service.d
+	install -D pulse/75-pulseaudio-qubes.preset \
+		$(DESTDIR)$(USER_DROPIN_DIR)-preset/75-pulseaudio-qubes.preset
 
 install-systemd:
 	install -m 0644 -D appvm-scripts/qubes-gui-agent.service \

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -72,8 +72,9 @@ package_qubes-vm-pulseaudio() {
 
 pkgdesc="Pulseaudio support for Qubes VM"
 depends=('alsa-lib' 'alsa-utils' 'pulseaudio-alsa' 'pulseaudio<=16.1')
+conflicts=('qubes-core-agent<4.2.5')
 install=PKGBUILD-pulseaudio.install
-pa_ver=$((pkg-config --modversion libpulse 2>/dev/null || echo 0.0) | cut -f 1 -d "-")
+pa_ver=$( (pkg-config --modversion libpulse 2>/dev/null || echo 0.0) | cut -f 1 -d "-")
 
 make install-pulseaudio DESTDIR=$pkgdir PA_VER=$pa_ver LIBDIR=/usr/lib USRLIBDIR=/usr/lib SYSLIBDIR=/usr/lib
 

--- a/debian/control
+++ b/debian/control
@@ -99,9 +99,13 @@ Depends:
     libpulse0,
     ${shlibs:Depends},
     ${pulse:Depends},
-    ${misc:Depends}
-Replaces: qubes-gui-agent (<< 4.1.9-1)
-Breaks: qubes-gui-agent (<< 4.1.9-1)
+    ${misc:Depends},
+Replaces:
+ qubes-gui-agent (<< 4.1.9-1),
+ qubes-core-agent (<< 4.2.5-1),
+Breaks:
+ qubes-gui-agent (<< 4.1.9-1),
+ qubes-core-agent (<< 4.2.5-1),
 Description: Audio support for Qubes VM
  Pulseaudio module to enable sound support in Qubes VM
 

--- a/debian/pulseaudio-qubes.install
+++ b/debian/pulseaudio-qubes.install
@@ -3,3 +3,5 @@ etc/xdg/autostart/qubes-pulseaudio.desktop
 usr/bin/start-pulseaudio-with-vchan
 usr/lib/pulse-*/modules/module-vchan-sink.so
 usr/lib/tmpfiles.d/qubes-pulseaudio.conf
+usr/lib/systemd/user-preset/75-pulseaudio-qubes.preset
+usr/lib/systemd/user/pulseaudio.service.d/30_qubes.conf

--- a/pulse/75-pulseaudio-qubes.preset
+++ b/pulse/75-pulseaudio-qubes.preset
@@ -1,0 +1,8 @@
+
+# Units below this line will be re-preset on package upgrade 
+
+# conflicts with pulseaudio
+disable pipewire.socket
+disable pipewire.service
+disable wireplumber.service
+

--- a/pulse/pulseaudio.service.d/30_qubes.conf
+++ b/pulse/pulseaudio.service.d/30_qubes.conf
@@ -1,0 +1,7 @@
+[Unit]
+ConditionPathExists=/etc/pulse/qubes-default.pa
+
+[Service]
+ExecStartPre=-/usr/bin/qubesdb-read -w /qubes-audio-domain-xid
+ExecStart=
+ExecStart=/usr/bin/pulseaudio --start -n --file=/etc/pulse/qubes-default.pa --exit-idle-time=-1 --daemonize=no --log-target=journal

--- a/pulse/start-pulseaudio-with-vchan
+++ b/pulse/start-pulseaudio-with-vchan
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh --
 #
 # The Qubes OS Project, http://www.qubes-os.org
 #
@@ -17,10 +17,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-#
-#
+
+set -eu
 
 type pulseaudio >/dev/null 2>&1 || exit 0
+
+if [ -f /lib/systemd/user/pulseaudio.service ]; then
+  # pulseaudio will be managed by systemd, do nothing
+  exit 0
+fi
 
 qubesdb-read -w /qubes-audio-domain-xid >/dev/null
 

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -87,6 +87,8 @@ Summary: Audio support for Qubes VM
 # It is possible that our code will work fine with any later pulseaudio
 # version; but this needs to be verified for each pulseaudio version.
 Requires:	pulseaudio = %{pa_ver_full}
+# Needed so that systemd can manage PulseAudio
+Conflicts:	qubes-core-agent < 4.2.5
 Conflicts:  qubes-gui-vm < 4.0.0
 
 %description -n pulseaudio-qubes
@@ -136,6 +138,32 @@ fi
 
 sed -i '/^autospawn/d' /etc/pulse/client.conf
 echo autospawn=no >> /etc/pulse/client.conf
+
+# simplified version of preset_units() from core-agent-linux
+preset_units() {
+    local represet=
+    cat "$1" | while read action unit_name
+    do
+        if [ "$action" = "#" -a "$unit_name" = "Units below this line will be re-preset on package upgrade" ]
+        then
+            represet=1
+            continue
+        fi
+        echo "$action $unit_name" | grep -q '^[[:space:]]*[^#;]' || continue
+        [ -n "$action" -a -n "$unit_name" ] || continue
+        if [ "$2" = "initial" -o "$represet" = "1" ]
+        then
+            systemctl --no-reload --global preset "$unit_name" >/dev/null 2>&1 || :
+        fi
+    done
+}
+
+if [ $1 -eq 1 ]
+then
+    preset_units /usr/lib/systemd/user-preset/75-pulseaudio-qubes.preset initial
+else
+    preset_units /usr/lib/systemd/user-preset/75-pulseaudio-qubes.preset upgrade
+fi
 
 %preun
 if [ "$1" = 0 ] ; then
@@ -205,6 +233,8 @@ rm -f %{name}-%{version}
 /usr/bin/start-pulseaudio-with-vchan
 %{pa_module_dir}/module-vchan-sink.so
 /etc/xdg/autostart/qubes-pulseaudio.desktop
+/usr/lib/systemd/user-preset/75-pulseaudio-qubes.preset
+/usr/lib/systemd/user/pulseaudio.service.d/30_qubes.conf
 
 %files xfce
 /etc/X11/xinit/xinitrc.d/60xfce-desktop.sh


### PR DESCRIPTION
If systemd will be managing PulseAudio, then start-pulseaudio-with-vchan
should do nothing.  This requires qubes-core-agent >= 4.2.1, as older
versions disable pulseaudio.socket and pulseaudio.service.  Finally,
fix a bug in the Arch PKGBUILD.