### PR TITLE
Switch to protocol 1.4

### DIFF
--- a/common/list.c
+++ b/common/list.c
@@ -20,6 +20,7 @@
  */
 
 #include "list.h"
+#include <assert.h>
 #include <malloc.h>
 struct genlist *list_new(void)
 {
@@ -59,6 +60,9 @@ struct genlist *list_insert(struct genlist *l, long key, void *data)
 
 void list_remove(struct genlist *l)
 {
+    assert(l->prev != l && l->next != l && "Attempt to remove node from empty list?");
+    assert(l->prev->next == l && "corrupt list");
+    assert(l->next->prev == l && "corrupt list");
     l->next->prev = l->prev;
     l->prev->next = l->next;
     free(l);

--- a/gui-agent/Makefile
+++ b/gui-agent/Makefile
@@ -20,7 +20,7 @@
 #
 
 CC ?= gcc
-CFLAGS += -I../include/ `pkg-config --cflags vchan` -g -Wall -Wextra -Werror -pie -fPIC
+CFLAGS += -I../include/ `pkg-config --cflags vchan` -g -Wall -Wextra -Werror -fPIC
 OBJS = vmside.o \
 	../gui-common/txrx-vchan.o ../gui-common/error.o ../common/list.o ../gui-common/encoding.o 
 LIBS = -lX11 -lXdamage -lXcomposite -lXfixes `pkg-config --libs vchan` -lqubesdb

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -66,7 +66,7 @@
 /* Supported protocol version */
 
 #define PROTOCOL_VERSION_MAJOR 1
-#define PROTOCOL_VERSION_MINOR 4
+#define PROTOCOL_VERSION_MINOR 7
 #define PROTOCOL_VERSION (PROTOCOL_VERSION_MAJOR << 16 | PROTOCOL_VERSION_MINOR)
 
 #if !(PROTOCOL_VERSION_MAJOR == QUBES_GUID_PROTOCOL_VERSION_MAJOR && \
@@ -410,7 +410,7 @@ static void process_xevent_createnotify(Ghandles * g, XCreateWindowEvent * ev)
     }
 
     if (ev->parent != g->root_win) {
-        /* GUI daemon won’t support this much longer */
+        /* GUI daemon no longer supports this */
         fprintf(stderr,
                 "CREATE with non-root parent window 0x%x\n",
                 (unsigned int)ev->parent);
@@ -2127,6 +2127,12 @@ static void handle_message(Ghandles * g)
         case MSG_WINDOW_FLAGS:
             handle_window_flags(g, hdr.window);
             break;
+        case MSG_DESTROY:
+            /* currently not used */
+            break;
+        case MSG_WINDOW_DUMP_ACK:
+            /* TODO: use this */
+            break;
         default:
             fprintf(stderr, "got unknown msg type %d, ignoring\n", hdr.type);
             while (hdr.untrusted_len > 0) {
@@ -2165,7 +2171,7 @@ static void handshake(Ghandles *g)
     if (version > PROTOCOL_VERSION ||
         major_version != PROTOCOL_VERSION_MAJOR ||
         minor_version < 4)
-        err(2, "Incompatible GUI daemon version (offered %" PRIu16 ".%" PRIu16
+        errx(2, "Incompatible GUI daemon version (offered %" PRIu16 ".%" PRIu16
                 ", got %" PRIu16 ".%" PRIu16 ")",
                 PROTOCOL_VERSION_MAJOR, PROTOCOL_VERSION_MINOR,
                 major_version, minor_version);

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -507,7 +507,7 @@ void send_pixmap_grant_refs(Ghandles * g, XID window)
                 window);
         return;
     }
-    wd_msg_buf = alloca(wd_msg_len);
+    wd_msg_buf = malloc(wd_msg_len);
     if (!wd_msg_buf) {
         fprintf(stderr, "Failed to allocate memory for window dump 0x%lx\n",
                 window);
@@ -531,6 +531,7 @@ void send_pixmap_grant_refs(Ghandles * g, XID window)
     hdr.untrusted_len = wd_msg_len;
     write_struct(g->vchan, hdr);
     write_data(g->vchan, (char *) wd_msg_buf, wd_msg_len);
+    free(wd_msg_buf);
 }
 
 /* return 1 on success, 0 otherwise */

--- a/include/list.h
+++ b/include/list.h
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
+#pragma once
 
 struct genlist {
 	long key;

--- a/xf86-input-mfndev/configure.ac
+++ b/xf86-input-mfndev/configure.ac
@@ -66,6 +66,7 @@ AC_SUBST([sdkdir])
 DRIVER_NAME=qubes
 AC_SUBST([DRIVER_NAME])
 
-AC_OUTPUT([Makefile
+AC_CONFIG_FILES([Makefile
            src/Makefile
            xorg-qubes.pc])
+AC_OUTPUT

--- a/xf86-input-mfndev/src/qubes.c
+++ b/xf86-input-mfndev/src/qubes.c
@@ -490,8 +490,6 @@ static WindowPtr id2winptr(unsigned int xid)
         return NULL;
 }
 
-static void dump_window_grant_refs(int window_id, int fd);
-
 static void dump_window_grant_refs(int window_id, int fd)
 {
     ScreenPtr screen;
@@ -513,6 +511,8 @@ static void dump_window_grant_refs(int window_id, int fd)
         xf86Msg(X_ERROR, "can't dump window without grant table allocation\n");
         goto send_response;
     }
+
+    xf86_qubes_pixmap_add_to_list(priv);
 
     wd_hdr.type = WINDOW_DUMP_TYPE_GRANT_REFS;
     wd_hdr.width = pixmap->drawable.width;
@@ -633,6 +633,12 @@ static void process_request(int fd, InputInfoPtr pInfo)
         break;
     case 'K':
         xf86PostKeyboardEvent(pInfo->dev, cmd.arg1, cmd.arg2);
+        break;
+    case 'a':
+        xf86_qubes_pixmap_remove_list_head();
+        break;
+    case 'A':
+        xf86_qubes_pixmap_remove_list_all();
         break;
     default:
         xf86Msg(X_INFO, "randdev: unknown command %u\n", cmd.type);

--- a/xf86-qubes-common/include/xf86-qubes-common.h
+++ b/xf86-qubes-common/include/xf86-qubes-common.h
@@ -10,6 +10,8 @@ struct xf86_qubes_pixmap {
     size_t pages; // Number of pages
     uint32_t *refs; // Pointer to grant references
     uint8_t *data; // Local mapping
+    uint32_t refcount; // 1-biased reference count: stores number of references
+                       // minus 1
 };
 
 // Only intended for use in the Qubes xorg modules.

--- a/xf86-qubes-common/include/xf86-qubes-common.h
+++ b/xf86-qubes-common/include/xf86-qubes-common.h
@@ -25,7 +25,13 @@ extern _X_EXPORT void xf86_qubes_pixmap_set_private(
 extern _X_EXPORT struct xf86_qubes_pixmap *xf86_qubes_pixmap_get_private(
         PixmapPtr pixmap);
 
-// xenctrl and xorg headeres are not compatible. So define the requires
+_X_EXPORT void xf86_qubes_pixmap_incref(struct xf86_qubes_pixmap *);
+_X_EXPORT void xf86_qubes_free_pixmap_private(struct xf86_qubes_pixmap *);
+_X_EXPORT void xf86_qubes_pixmap_add_to_list(struct xf86_qubes_pixmap *);
+_X_EXPORT void xf86_qubes_pixmap_remove_list_head(void);
+_X_EXPORT void xf86_qubes_pixmap_remove_list_all(void);
+
+// xenctrl and xorg headeres are not compatible, so define the required
 // constants here.
 #ifndef XC_PAGE_SHIFT
 #define XC_PAGE_SHIFT           12

--- a/xf86-video-dummy/configure.ac
+++ b/xf86-video-dummy/configure.ac
@@ -22,10 +22,7 @@
 
 # Initialize Autoconf
 AC_PREREQ([2.60])
-AC_INIT([xf86-video-dummy-qubes],
-        [0.3.6],
-        [http://wiki.qubes-os.org/trac],
-        [xf86-video-dummy-qubes])
+AC_INIT([xf86-video-dummy-qubes],[4.2.2],[https://github.com/QubesOS/qubes-issues],[xf86-video-dummy-qubes])
 AC_CONFIG_SRCDIR([Makefile.am])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR(.)
@@ -42,7 +39,7 @@ XORG_DEFAULT_OPTIONS
 
 # Initialize libtool
 AC_DISABLE_STATIC
-AC_PROG_LIBTOOL
+LT_INIT
 
 AH_TOP([#include "xorg-server.h"])
 
@@ -72,8 +69,6 @@ PKG_CHECK_MODULES(XORG, [xorg-server >= 1.0.99.901] xproto fontsproto $REQUIRED_
 # Checks for libraries.
 AC_CHECK_LIB([xengnttab], [xengntshr_open])
 
-# Checks for header files.
-AC_HEADER_STDC
 AC_CHECK_HEADER([xengnttab.h])
 
 

--- a/xf86-video-dummy/src/Makefile.am
+++ b/xf86-video-dummy/src/Makefile.am
@@ -29,6 +29,7 @@ AM_CFLAGS = $(XORG_CFLAGS) $(PCIACCESS_CFLAGS) $(GBM_CFLAGS)
 
 dummyqbs_drv_la_LTLIBRARIES = dummyqbs_drv.la
 dummyqbs_drv_la_LDFLAGS = -module -avoid-version
+dummyqbs_drv_la_CPPFLAGS = -I../../include
 dummyqbs_drv_la_LIBADD = $(XORG_LIBS) $(GBM_LIBS) -L../../xf86-qubes-common -lxf86-qubes-common
 dummyqbs_drv_ladir = @moduledir@/drivers
 
@@ -36,7 +37,8 @@ dummyqbs_drv_la_SOURCES = \
          compat-api.h \
          dummy_cursor.c \
          dummy_driver.c \
-         dummy.h
+         dummy.h \
+	 ../../common/list.c
 
 if DGA
 dummyqbs_drv_la_SOURCES +=	\

--- a/xf86-video-dummy/src/dummy.h
+++ b/xf86-video-dummy/src/dummy.h
@@ -14,6 +14,7 @@
 #include "compat-api.h"
 
 #include <xengnttab.h>
+#include "../../include/list.h"
 #include "../../xf86-qubes-common/include/xf86-qubes-common.h"
 
 #define DUMMY_MAX_SCREENS 16
@@ -94,6 +95,7 @@ typedef struct dummyRec
     Bool        (*CreateWindow)() ;     /* wrapped CreateWindow */
     Bool prop;
 
+    struct genlist queue;
     xengntshr_handle *xgs;
     uint32_t gui_domid;
 } DUMMYRec, *DUMMYPtr;

--- a/xf86-video-dummy/src/dummy_driver.c
+++ b/xf86-video-dummy/src/dummy_driver.c
@@ -828,6 +828,7 @@ qubes_alloc_pixmap_private(size_t size) {
     struct xf86_qubes_pixmap *priv;
     size_t pages;
 
+    assert(size < PTRDIFF_MAX);
     pages = (size + XC_PAGE_SIZE - 1) >> XC_PAGE_SHIFT;
 
     priv = calloc(1, sizeof(struct xf86_qubes_pixmap) + pages * sizeof(uint32_t));
@@ -929,6 +930,7 @@ qubes_destroy_pixmap(PixmapPtr pixmap) {
     DUMMYPtr dPtr = DUMMYPTR(DUMMYScrn);
     struct xf86_qubes_pixmap *priv;
 
+    assert(pixmap->refcnt > 0);
     priv = xf86_qubes_pixmap_get_private(pixmap);
     if (priv != NULL && pixmap->refcnt == 1) {
         qubes_free_pixmap_private(dPtr, priv);


### PR DESCRIPTION
This breaks compatibility with protocol versions older than 1.4.
Therefore, it must not be merged until this some time after GUI daemon
4.1.23 reaches stable, as 4.1.22 is buggy and older versions only
support protocols 1.3 and below.