### PR TITLE
Remove duplicated button from titlebar of gnome applications

### DIFF
--- a/appvm-scripts/etc/xdg-debian/xsettingsd
+++ b/appvm-scripts/etc/xdg-debian/xsettingsd
@@ -5,6 +5,7 @@ Gtk/KeyThemeName "Adwaita"
 Gtk/MenuImages 1
 Gtk/ToolbarIconSize 2
 Gtk/ToolbarStyle "Icons"
+Gtk/DecorationLayout ":"
 
 Net/EnableEventSounds 0
 Net/EnableInputFeedbackSounds 0


### PR DESCRIPTION
This saves users who create new debian template-based domUs from having to install `gnome-settings-daemon` to remove duplicate buttons.

https://forum.qubes-os.org/t/3904
QubesOS/qubes-issues#2813