### PR TITLE
Workaround software rendering issues in GTK4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,8 @@ endif
 		$(DESTDIR)/etc/xdg/autostart/qubes-qrexec-fork-server.desktop
 	install -m 0644 -D appvm-scripts/etc/xdgautostart/qubes-keymap.desktop \
 		$(DESTDIR)/etc/xdg/autostart/qubes-keymap.desktop
+	install -m 0644 -D appvm-scripts/etc/xdgautostart/qubes-gtk4-workarounds.desktop \
+		$(DESTDIR)/etc/xdg/autostart/qubes-gtk4-workarounds.desktop
 	install -D -m 0644 appvm-scripts/usr/lib/sysctl.d/30-qubes-gui-agent.conf \
 		$(DESTDIR)/usr/lib/sysctl.d/30-qubes-gui-agent.conf
 	install -D -m 0644 appvm-scripts/lib/udev/rules.d/70-master-of-seat.rules \
@@ -205,6 +207,8 @@ endif
 		$(DESTDIR)/usr/lib/qubes/qubes-keymap.sh
 	install -D appvm-scripts/usr/lib/qubes/qubes-xorg-wrapper \
 		$(DESTDIR)/usr/lib/qubes/qubes-xorg-wrapper
+	install -D appvm-scripts/usr/lib/qubes/gtk4-workarounds.sh \
+		$(DESTDIR)/usr/lib/qubes/gtk4-workarounds.sh
 ifeq ($(shell lsb_release -is), Debian)
 	install -D -m 0644 appvm-scripts/etc/pam.d/qubes-gui-agent.debian \
 		$(DESTDIR)/etc/pam.d/qubes-gui-agent

--- a/appvm-scripts/etc/xdgautostart/qubes-gtk4-workarounds.desktop
+++ b/appvm-scripts/etc/xdgautostart/qubes-gtk4-workarounds.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Version=1.0
+Encoding=UTF-8
+Name=Apply Qubes GTK4 workarounds
+Exec=/usr/lib/qubes/gtk4-workarounds.sh
+Terminal=false
+Type=Application
+OnlyShowIn=X-QUBES;

--- a/appvm-scripts/usr/lib/qubes/gtk4-workarounds.sh
+++ b/appvm-scripts/usr/lib/qubes/gtk4-workarounds.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -eo pipefail
+
+# when changing, bump the CSS_VERSION below to force updating user config
+CSS='/* QUBES BEGIN */
+/* Do not modify text until end marker, it will get overriden on update */
+/* See https://github.com/QubesOS/qubes-issues/issues/8081#issuecomment-1473412028 */
+.solid-csd popover > contents, .solid-csd .hover-assistant, .solid-csd .completion {
+	box-shadow: none;
+	border-radius: 0px;
+	margin: 0px;
+}
+popover > contents {
+    border-style: none;
+}
+
+popover > arrow {
+	border-style: none;
+}
+popover {
+	background-color: @view_bg_color;
+}
+
+/* performance improvement with software rendering */
+window {
+	box-shadow: none;
+	padding: 0px;
+}
+
+/* 
+ * Spinner monopolize the whole idle loop, see
+ * https://github.com/QubesOS/qubes-issues/issues/7921
+ */
+spinner {
+    animation-play-state: paused;
+    opacity: 0;
+}
+/* QUBES END */'
+
+CSS_PATH="$HOME/.config/gtk-4.0/gtk.css"
+CSS_VERSION=1
+CSS_FLAG_FILE="$HOME/.config/gtk-4.0/qubes-patched"
+
+if [ -r "$CSS_FLAG_FILE" ] && [ "$(<"$CSS_FLAG_FILE")" -eq "$CSS_VERSION" ]; then
+    # already patched
+    exit 0
+fi
+
+
+if [ ! -e "$CSS_PATH" ] || ! grep -q "QUBES BEGIN" "$CSS_PATH"; then
+    mkdir -p "${CSS_PATH%/*}"
+    echo "$CSS" >> "$CSS_PATH"
+else
+    echo "$CSS" | sed -i -e "/QUBES BEGIN/,/QUBES END/{r /dev/stdin" -e "; d }" "$CSS_PATH"
+fi
+echo "$CSS_VERSION" > "$CSS_FLAG_FILE"

--- a/debian/qubes-gui-agent.install
+++ b/debian/qubes-gui-agent.install
@@ -10,6 +10,7 @@ etc/security/limits.d/90-qubes-gui.conf
 etc/qubes-rpc/qubes.SetMonitorLayout
 etc/qubes-rpc/qubes.GuiVMSession
 etc/qubes/post-install.d/20-qubes-guivm-gui-agent.sh
+etc/xdg/autostart/qubes-gtk4-workarounds.desktop
 etc/xdg/autostart/qubes-icon-sender.desktop
 etc/xdg/autostart/qubes-qrexec-fork-server.desktop
 etc/xdg/autostart/qubes-keymap.desktop
@@ -29,6 +30,7 @@ usr/bin/qubes-session
 usr/bin/qubes-set-monitor-layout
 usr/lib/qubes/icon-sender
 usr/lib/sysctl.d/30-qubes-gui-agent.conf
+usr/lib/qubes/gtk4-workarounds.sh
 usr/lib/qubes/qubes-gui-agent-pre.sh
 usr/lib/qubes/qubes-keymap.sh
 usr/lib/qubes/qubes-xorg-wrapper

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -219,11 +219,13 @@ rm -f %{name}-%{version}
 /lib/systemd/system/qubes-gui-agent.service
 /lib/udev/rules.d/70-master-of-seat.rules
 /usr/lib/sysctl.d/30-qubes-gui-agent.conf
+/usr/lib/qubes/gtk4-workarounds.sh
 /usr/lib/qubes/qubes-gui-agent-pre.sh
 /usr/lib/qubes/qubes-keymap.sh
 /usr/lib/qubes/qubes-xorg-wrapper
 %{_datadir}/glib-2.0/schemas/20_qubes-gui-vm.gschema.override
 /usr/lib/qubes/icon-sender
+/etc/xdg/autostart/qubes-gtk4-workarounds.desktop
 /etc/xdg/autostart/qubes-icon-sender.desktop
 /etc/xdg/autostart/qubes-qrexec-fork-server.desktop
 /etc/xdg/autostart/qubes-keymap.desktop


### PR DESCRIPTION
Apply custom CSS to workaround software rendering issues:
 - black frames around popup menus
 - spinner monopolizing the whole "idle loop", preventing actual work to
   be done (for example in nautilus)

This is heavily based on work by @sityvb and @noskb.

The spinner disabler is done in two parts:
 - animation-play-state disables actual spinning (this part frees up the
   idle loop)
 - opacity hides the now frozen spinner to avoid confusion (at least a
   bit); it could be 'display: none', but that (at least in nautilus) is
   programatically overridden

The patch is applied on user login and flag file is created to not
reapply it needlessly.

Fixes QubesOS/qubes-issues#8081
Fixes QubesOS/qubes-issues#7921
Fixes QubesOS/qubes-issues#8115