### PR TITLE
Support alternate user names

### DIFF
--- a/appvm-scripts/etc/securitylimits.d/90-qubes-gui.conf
+++ b/appvm-scripts/etc/securitylimits.d/90-qubes-gui.conf
@@ -1,4 +1,5 @@
-# Qubes GUI agent needs to mlock() all the composition buffers, so they are
-# constant physical address
+# Old Qubes GUI agent needs to mlock() all the composition buffers, so they are
+# constant physical addresses.  Current GUI agent needs to allocate large
+# amounts of pinned memory for grant sharing.
 user   soft memlock 131072
 user   hard memlock 131072

--- a/appvm-scripts/etc/securitylimits.d/90-qubes-gui.conf
+++ b/appvm-scripts/etc/securitylimits.d/90-qubes-gui.conf
@@ -1,5 +1,4 @@
 # Old Qubes GUI agent needs to mlock() all the composition buffers, so they are
 # constant physical addresses.  Current GUI agent needs to allocate large
 # amounts of pinned memory for grant sharing.
-user   soft memlock 131072
-user   hard memlock 131072
+@qubes   - memlock 131072

--- a/appvm-scripts/usr/lib/qubes/qubes-gui-agent-pre.sh
+++ b/appvm-scripts/usr/lib/qubes/qubes-gui-agent-pre.sh
@@ -2,8 +2,10 @@
 
 . /usr/lib/qubes/init/functions
 
+user=$(qubesdb-read /default-user) || exit
 # pretend tha user is at local console
-mkdir -p /var/run/console ; /bin/touch /var/run/console/user
+mkdir -p /var/run/console
+: > "/var/run/console/$user"
 
 # set corresponding display for guivm
 if qsvc guivm-gui-agent; then

--- a/appvm-scripts/usrbin/qubes-session
+++ b/appvm-scripts/usrbin/qubes-session
@@ -32,7 +32,9 @@ loginctl activate "$XDG_SESSION_ID"
 # Qubes environment using the standard environment.d
 # facility.  Documentation for the facility is at:
 # https://www.freedesktop.org/software/systemd/man/environment.d.html
-env=$(set -o pipefail && { systemctl --user show-environment | sed 's/^/export /';}) && eval "$env" || exit
+set -a # export all variables
+env=$(systemctl --user show-environment) && eval "$env" || exit
+set +a
 
 
 if qsvc guivm-gui-agent; then


### PR DESCRIPTION
The default user might not be named `user`.