### PR TITLE
Fix two qubes-keymap.sh issues

### DIFF
--- a/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
+++ b/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
@@ -11,7 +11,7 @@ set_keyboard_layout() {
     KEYMAP_LAYOUT="$(echo "$KEYMAP"+ | cut -f 1 -d +)"
     KEYMAP_VARIANT="$(echo "$KEYMAP"+ | cut -f 2 -d +)"
     KEYMAP_OPTIONS="$(echo "$KEYMAP"+ | cut -f 3 -d +)"
-    if [ "$KEYMAP_LAYOUT" != "us" ]; then
+    if [ "$KEYMAP_LAYOUT" != "us" -a "$KEYMAP_LAYOUT" != "si" ]; then
         KEYMAP_LAYOUT="$KEYMAP_LAYOUT,us"
         KEYMAP_VARIANT="$KEYMAP_VARIANT,"
     fi

--- a/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
+++ b/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
@@ -21,7 +21,7 @@ set_keyboard_layout() {
     fi
 
     if [ -n "$KEYMAP_OPTIONS" ]; then
-        KEYMAP_OPTIONS="-option $KEYMAP_OPTIONS"
+        KEYMAP_OPTIONS="-option -option $KEYMAP_OPTIONS"
     fi
 
     # Set layout on all DISPLAY


### PR DESCRIPTION
Avoid xkb option accumulation
https://github.com/QubesOS/qubes-issues/issues/8230

Don't add ",us" for layout "si"
https://github.com/QubesOS/qubes-gui-agent-linux/pull/139#issuecomment-1627711217