### PR TITLE
Do not override default clock rate or quantum

### DIFF
--- a/pipewire/30_qubes.conf
+++ b/pipewire/30_qubes.conf
@@ -1,7 +1,7 @@
 context.properties = {
-   default.clock.rate = 44100
-   default.clock.min-quantum = 512
-   default.clock.max-quantum = 512
+   # Uncomment this if the default quantum is too small and you are
+   # experiencing a bunch of overruns or underruns.
+   #default.clock.min-quantum = 512
 
    # The Qubes PipeWire module requires a buffer size to be provided.
    # The record buffer size comes from the org.qubes-os.record-buffer-size


### PR DESCRIPTION
This turns out to totally break Firefox's WebRTC implementation.  The clock rate and maximum quantum are deleted, while the minimum quantum is kept but commented out by default.  Users can uncomment it if they are experiencing large numbers of xruns.

With this change, I still get occasional underruns, but the audio is generally usable.  Previously it wasn't.  The underruns will be fixed by using PipeWire's delay-locked loop implementation, combined with its rate control support.

Fixes: QubesOS/qubes-issues#8415 (release blocker!)