### PR TITLE
pipewire: adjust buffer parameters

### DIFF
--- a/pipewire/qubes-pw-module.c
+++ b/pipewire/qubes-pw-module.c
@@ -790,9 +790,9 @@ static void stream_param_changed(void *data, uint32_t id,
 doit:
     params[0] = spa_pod_builder_add_object(&b,
             SPA_TYPE_OBJECT_ParamBuffers, SPA_PARAM_Buffers,
-            SPA_PARAM_BUFFERS_buffers, SPA_POD_Int(1),
+            SPA_PARAM_BUFFERS_buffers, SPA_POD_CHOICE_RANGE_Int(8, 2, 64),
             SPA_PARAM_BUFFERS_blocks, SPA_POD_Int(1),
-            SPA_PARAM_BUFFERS_size, SPA_POD_Int(2048),
+            SPA_PARAM_BUFFERS_size, SPA_POD_Int(2048 * (int)impl->frame_size),
             SPA_PARAM_BUFFERS_stride, SPA_POD_Int((int)impl->frame_size),
             SPA_PARAM_BUFFERS_dataType, SPA_POD_CHOICE_FLAGS_Int((1 << SPA_DATA_MemPtr)));
     spa_assert_se(params[0]);


### PR DESCRIPTION
Allow more than one buffer (to allow application / daemon preparing next
buffer when previous one is being processed). And also adjust buffer
size based on other pipewire modules.

QubesOS/qubes-issues#8415