### PR TITLE
Allow Qubes group to use all realtime priorities

### DIFF
--- a/appvm-scripts/etc/securitylimits.d/90-qubes-gui.conf
+++ b/appvm-scripts/etc/securitylimits.d/90-qubes-gui.conf
@@ -2,3 +2,7 @@
 # constant physical addresses.  Current GUI agent needs to allocate large
 # amounts of pinned memory for grant sharing.
 @qubes   - memlock 131072
+
+# Qubes group is trusted and this makes audio handling easier
+@qubes   - nice -20
+@qubes   - rtprio unlimited


### PR DESCRIPTION
This makes low-latency audio easier without having to use rtkit.