### PR TITLE
Allow carriage return in secure clipboard

### DIFF
--- a/gui-agent/encoding.c
+++ b/gui-agent/encoding.c
@@ -114,7 +114,8 @@ bool is_valid_clipboard_string_from_vm(unsigned char *untrusted_s)
     for (; *untrusted_s; untrusted_s++) {
         // allow only non-control ASCII chars
         if ((*untrusted_s >= 0x20 && *untrusted_s <= 0x7E) ||
-             *untrusted_s == '\n' || *untrusted_s == '\t')
+             *untrusted_s == '\n' || *untrusted_s == '\t' ||
+             (*untrusted_s == '\r' && untrusted_s[1] == '\n'))
             continue;
         if (*untrusted_s >= 0x80) {
             utf8_ret = validate_utf8_char(untrusted_s);


### PR DESCRIPTION
Fixes copy & paste of data containing it, such as from Windows.

Fixes: QubesOS/qubes-issues#8937