### PR TITLE
Add xorg-xrandr dependence for vm-archlinux

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -52,6 +52,7 @@ build() {
 package_qubes-vm-gui() {
     depends=(
     'xorg-xinit'
+    'xorg-xrandr'
     'libxcomposite'
     'zenity'
     'qubes-libvchan'


### PR DESCRIPTION
qubes-set-monitor-layout relies on calling xrandr for successful operation. Make sure the archlinux template has the binary present, so the script doesn't end up running an infinite loop, utilizing CPU cycles for nothing.