### PR TITLE
Handle oversized clipboard for GUI protocol 1.8

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,14 +1,14 @@
 include:
-- file: /r4.2/gitlab-base.yml
+- file: /r4.3/gitlab-base.yml
   project: QubesOS/qubes-continuous-integration
   ref: $CI_BRANCH_REF
-- file: /r4.2/gitlab-host.yml
+- file: /r4.3/gitlab-host.yml
   project: QubesOS/qubes-continuous-integration
   ref: $CI_BRANCH_REF
-- file: /r4.2/gitlab-vm.yml
+- file: /r4.3/gitlab-vm.yml
   project: QubesOS/qubes-continuous-integration
   ref: $CI_BRANCH_REF
-- file: /r4.2/gitlab-host-vm-openqa.yml
+- file: /r4.3/gitlab-host-vm-openqa.yml
   project: QubesOS/qubes-continuous-integration
   ref: $CI_BRANCH_REF
 variables:


### PR DESCRIPTION
If vmside clipboard is over the maximum limit, sending one byte over maximum limit should trigger inter-vm clipboard rejection instead of truncation.

Fixes: https://github.com/QubesOS/qubes-issues/issues/9296
Fixes: https://github.com/QubesOS/qubes-issues/issues/5220