### PR TITLE
rpm: depend on cvt in F41+

### DIFF
--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -91,6 +91,9 @@ Requires:	qubes-db >= 4.1.4
 Requires:	python%{python3_pkgversion}-xcffib
 Requires:   xorg-x11-server-Xorg
 Requires:   xorg-x11-server-Xephyr
+%if 0%{?fedora} >= 41
+Requires:   cvt
+%endif
 Requires:   setxkbmap
 Requires:   xsetroot
 Requires:   xrdb


### PR DESCRIPTION
cvt tool is split out of xorg-x11-server-Xorg in Fedora 41+, add
explicit dependency for it, as it's needed by qubes.SetMonitorLayout
service.

QubesOS/qubes-issues#9244