### PR TITLE
Improve handling early startup issues

### DIFF
--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -1558,9 +1558,16 @@ static void wait_for_unix_socket(Ghandles *g)
 
     addrlen = sizeof(peer);
     fprintf (stderr, "Waiting on %s socket...\n", SOCKET_ADDRESS);
+    if (g->x_pid == (pid_t)-1) {
+        fprintf(stderr, "Xorg exited in the meantime, aborting\n");
+        exit(1);
+    }
     g->xserver_fd = accept(g->xserver_listen_fd, (struct sockaddr *) &peer, &addrlen);
     if (g->xserver_fd == -1) {
-        perror("unix accept");
+        if (errno == EINTR && g->x_pid == (pid_t)-1)
+            fprintf(stderr, "Xorg exited in the meantime, aborting\n");
+        else
+            perror("unix accept");
         exit(1);
     }
     fprintf (stderr, "Ok, somebody connected.\n");
@@ -2317,6 +2324,21 @@ static _Noreturn void handle_sigterm(int UNUSED(sig),
     exit(0);
 }
 
+static void handle_sigchld(int UNUSED(sig),
+        siginfo_t *UNUSED(info), void *UNUSED(context))
+{
+    Ghandles *g = ghandles_for_vchan_reinitialize;
+    if (g->x_pid != (pid_t)-1) {
+        int status;
+        pid_t pid = waitpid(g->x_pid, &status, WNOHANG);
+        if (pid == g->x_pid && (WIFEXITED(status) || WIFSIGNALED(status)))
+            /* TODO: consider saving also exit status, but right now gui-agent
+             * would handle it the same regardless, so maybe later, just for
+             * logging purposes */
+            g->x_pid = -1;
+    }
+}
+
 static void usage(void)
 {
     fprintf(stderr, "Usage: qubes_gui [options]\n");
@@ -2456,7 +2478,13 @@ int main(int argc, char **argv)
     vchan_register_at_eof(handle_guid_disconnect);
 
     ghandles_for_vchan_reinitialize = &g;
-    signal(SIGCHLD, SIG_IGN);
+    struct sigaction sigchld_handler = {
+        .sa_sigaction = handle_sigchld,
+        .sa_flags = SA_SIGINFO,
+    };
+    sigemptyset(&sigchld_handler.sa_mask);
+    if (sigaction(SIGCHLD, &sigchld_handler, NULL))
+        err(1, "sigaction");
     struct sigaction sigterm_handler = {
         .sa_sigaction = handle_sigterm,
         .sa_flags = SA_SIGINFO,
@@ -2543,6 +2571,11 @@ int main(int argc, char **argv)
     };
     for (;;) {
         int busy;
+
+        if (g.x_pid == -1) {
+            fprintf(stderr, "Xorg exited prematurely\n");
+            exit(1);
+        }
 
         fds[0].fd = libvchan_fd_for_select(g.vchan);
         wait_for_vchan_or_argfd(g.vchan, fds, QUBES_ARRAY_SIZE(fds));

--- a/xf86-input-mfndev/src/qubes.c
+++ b/xf86-input-mfndev/src/qubes.c
@@ -506,6 +506,12 @@ static int QubesControl(DeviceIntPtr device, int what)
                         "%s: cannot open device; sleeping...\n",
                         pInfo->name);
                 sleep(1);
+                if (xf86ServerIsExiting()) {
+                    xf86Msg(X_ERROR,
+                            "%s: cannot open device, server exiting, aborting\n",
+                            pInfo->name);
+                    return BadAlloc;
+                }
             }
         } while (pInfo->fd < 0);
 

--- a/xf86-input-mfndev/src/qubes.c
+++ b/xf86-input-mfndev/src/qubes.c
@@ -390,7 +390,7 @@ int connect_unix_socket(QubesDevicePtr pQubes)
     struct sockaddr_un remote;
 
     if ((s = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
-        perror("socket");
+        xf86Msg(X_ERROR, "socket(%s): %s\n", pQubes->device, strerror(errno));
         return -1;
     }
 
@@ -399,7 +399,7 @@ int connect_unix_socket(QubesDevicePtr pQubes)
     strncpy(remote.sun_path, pQubes->device, sizeof(remote.sun_path));
     len = strlen(remote.sun_path) + sizeof(remote.sun_family);
     if (connect(s, (struct sockaddr *) &remote, len) == -1) {
-        perror("connect");
+        xf86Msg(X_ERROR, "connect(%s): %s\n", pQubes->device, strerror(errno));
         close(s);
         return -1;
     }


### PR DESCRIPTION
Better handle stopping the service while it's still starting up. And also improve handling Xorg startup errors (much simpler alternative to #176).