### PR TITLE
pipewire: prevent starting in root session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,10 @@ install-pipewire:
 	install -d $(DESTDIR)/etc/qubes/post-install.d
 	install -m 0755 appvm-scripts/etc/qubes/post-install.d/20-qubes-pipewire.sh \
                 $(DESTDIR)/etc/qubes/post-install.d/20-qubes-pipewire.sh
+	install -d $(DESTDIR)$(USERUNITDIR)/pipewire.service.d
+	install -m 0644 appvm-scripts/lib/systemd/user/pipewire.service.d/30_qubes.conf \
+		$(DESTDIR)$(USERUNITDIR)/pipewire.service.d/30_qubes.conf
+
 
 .PHONY: install-systemd
 install-systemd:

--- a/appvm-scripts/lib/systemd/user/pipewire.service.d/30_qubes.conf
+++ b/appvm-scripts/lib/systemd/user/pipewire.service.d/30_qubes.conf
@@ -1,0 +1,3 @@
+[Unit]
+# Avoid pipewire in root's session to not steal user's connection to the audiovm
+ConditionUser=!root

--- a/debian/pipewire-qubes.install
+++ b/debian/pipewire-qubes.install
@@ -2,4 +2,5 @@ usr/share/pipewire/pipewire.conf.d/30_qubes.conf
 usr/share/licenses/pipewire-qubes/COPYING
 usr/lib/x86_64-linux-gnu/pipewire-0.3/libpipewire-module-qubes.so
 lib/systemd/user-preset/74-qubes-vm.preset
+lib/systemd/user/pipewire.service.d/30_qubes.conf
 etc/qubes/post-install.d/20-qubes-pipewire.sh

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -349,6 +349,7 @@ rm -f %{name}-%{version}
 %dir %_datadir/pipewire/pipewire.conf.d
 %_datadir/pipewire/pipewire.conf.d/30_qubes.conf
 %_userpresetdir/74-qubes-vm.preset
+%_userunitdir/pipewire.service.d/30_qubes.conf
 %_libdir/pipewire-0.3/libpipewire-module-qubes.so
 %dir %_defaultlicensedir/pipewire-qubes
 %_defaultlicensedir/pipewire-qubes/COPYING


### PR DESCRIPTION
If root session is started early and pipewire gets started as part of
it, it may connect to the audiovm earlier than the user's instance,
effectively stealing the connection. Upstream already has
ConditionUser=!root in relevant pulseaudio units, but not in pipewire
ones. Add similar condition to pipewire.service unit.

Fixes QubesOS/qubes-issues#9619