### PR TITLE
disable qubes-icon-sender on sys-net and sys-usb

### DIFF
--- a/window-icon-updater/qubes-icon-sender.desktop
+++ b/window-icon-updater/qubes-icon-sender.desktop
@@ -8,3 +8,4 @@ Type=Application
 Categories=
 GenericName=
 OnlyShowIn=X-QUBES;
+AutostartCondition=unless-exists /var/run/qubes-service/minimal-netvm;unless-exists /var/run/qubes-service/minimal-usbvm


### PR DESCRIPTION
Qubes icon sender allows to update applications windows icons. In practice, few windows are opened on the sys-vms. Disabling this service allows to recover some RAM without causing inconvenience.