### PR TITLE
xf86-video-dummy: fix type of CreateWindow field

### DIFF
--- a/xf86-video-dummy/src/dummy.h
+++ b/xf86-video-dummy/src/dummy.h
@@ -92,7 +92,7 @@ typedef struct dummyRec
     dummy_colors colors[256];
     pointer* FBBase;
     struct xf86_qubes_pixmap *FBBasePriv;
-    Bool        (*CreateWindow)() ;     /* wrapped CreateWindow */
+    CreateWindowProcPtr CreateWindow;     /* wrapped CreateWindow */
     Bool prop;
 
     struct genlist queue;


### PR DESCRIPTION
The function takes an argument. Actual function used there was okay, but
the field in the structure used wrong type. And GCC 15 (rightfully)
started complaining.
Use CreateWindowProcPtr type to avoid similar issue in the future.

QubesOS/qubes-issues#9807