### PR TITLE
Format commands .qubesbuilder in single quotes

### DIFF
--- a/.qubesbuilder
+++ b/.qubesbuilder
@@ -21,7 +21,7 @@ vm:
       - debian
     source:
       commands:
-      - "sed -i 's/$(PA_VER)/1:$(PA_VER)/g' @SOURCE_DIR@/debian/rules"
+      - 'sed -i ''s/$(PA_VER)/1:$(PA_VER)/g'' @SOURCE_DIR@/debian/rules'
       - 'sed -i /Trolltech.conf/d @SOURCE_DIR@/debian/qubes-gui-agent.install'
       - '@PLUGINS_DIR@/source_deb/scripts/debian-quilt @SOURCE_DIR@/series-debian-vm.conf @SOURCE_DIR@/debian/patches'
 


### PR DESCRIPTION
When formatted in double quotes, the @SOURCE_DIR@ may be problematic
with windows builder, as it will contain backslashes, and that will be
misinterpreted by the yaml parser. While the windows paths are not
relevant for those commands, .qubesbuilder file need to render correctly
in that case too.