### PR TITLE
Disable auto-add GPU by default

### DIFF
--- a/appvm-scripts/etc/X11/xorg-qubes-x11vnc.conf.template
+++ b/appvm-scripts/etc/X11/xorg-qubes-x11vnc.conf.template
@@ -3,6 +3,10 @@ Section "Module"
     Load "glamoregl"
 EndSection
 
+Section "ServerFlags"
+    Option "AutoAddGPU" "false"
+EndSection
+
 Section "ServerLayout"
     Identifier      "Default Layout"
     Screen          0 "Screen0" 0 0

--- a/appvm-scripts/etc/X11/xorg-qubes.conf.template
+++ b/appvm-scripts/etc/X11/xorg-qubes.conf.template
@@ -3,6 +3,10 @@ Section "Module"
         Load "glamoregl"
 EndSection
 
+Section "ServerFlags"
+        Option "AutoAddGPU" "false"
+EndSection
+
 Section "ServerLayout"   
         Identifier     "Default Layout"
         Screen      0  "Screen0" 0 0  


### PR DESCRIPTION
The dummyqbs driver makes use of GPU render engine itself, and Xorg
trying to use that as separate device would conflict with it. But if
somebody want to use that anyway (to use a monitor connected to the
secondary GPU), it can be re-enabled manually using xorg.conf.d snippet.
But better, use sys-gui-gpu for that instead (or standard lightdm/sddm
etc instead of qubes-gui-agent).

This is yet another part of easing GPU passthrough for rendering
acceleration.