### PR TITLE
Remove '$env' after it's loaded into environment

### DIFF
--- a/appvm-scripts/usrbin/qubes-session
+++ b/appvm-scripts/usrbin/qubes-session
@@ -35,6 +35,7 @@ loginctl activate "$XDG_SESSION_ID"
 set -a # export all variables
 env=$(systemctl --user show-environment) && eval "$env" || exit
 set +a
+unset env
 
 
 if qsvc guivm-gui-agent; then


### PR DESCRIPTION
Retaining the multi-line variable that is formatted like then `env`
output is very confusing.

Fixes QubesOS/qubes-issues#9996