### PR TITLE
Include 'pointer' in the qubes input device name

### DIFF
--- a/appvm-scripts/etc/X11/xorg-qubes.conf.template
+++ b/appvm-scripts/etc/X11/xorg-qubes.conf.template
@@ -6,7 +6,7 @@ EndSection
 Section "ServerLayout"   
         Identifier     "Default Layout"
         Screen      0  "Screen0" 0 0  
-        InputDevice "qubesdev"
+        InputDevice "qubesdev pointer"
 EndSection
 
 Section "Device"
@@ -39,6 +39,6 @@ EndSection
 
 
 Section "InputDevice"
-        Identifier  "qubesdev"
+        Identifier  "qubesdev pointer"
         Driver      "qubes"
 EndSection


### PR DESCRIPTION
Apparently GTK considers an input device with abs axes a touchscreen,
unless it has "mouse" or "pointer" in the name. And changes behavior of
clicks to make it more "touch friendly". Rename the device to make GTK
apps happy.

Fixes QubesOS/qubes-issues#7316