### PR TITLE
Don't try to send grants for not realized windows

### DIFF
--- a/gui-agent/Makefile
+++ b/gui-agent/Makefile
@@ -23,9 +23,9 @@ CC ?= gcc
 CFLAGS += -I../include/ `pkg-config --cflags vchan` -g -Wall -Wextra -Werror -fPIC \
 	  -Wmissing-prototypes -Wstrict-prototypes -Wold-style-declaration \
 	  -Wold-style-definition
-OBJS = vmside.o txrx-vchan.o error.o list.o encoding.o
+OBJS = vmside.o txrx-vchan.o error.o list.o encoding.o video-ext-client.o
 LIBS = -lX11 -lXdamage -lXcomposite -lXfixes `pkg-config --libs vchan` -lqubesdb \
-	   -lunistring
+	   -lunistring -lXext
 
 
 all: qubes-gui qubes-gui-runuser

--- a/gui-agent/video-ext-client.c
+++ b/gui-agent/video-ext-client.c
@@ -1,0 +1,117 @@
+/*
+ * The Qubes OS Project, https://www.qubes-os.org/
+ *
+ * Copyright (C) 2025  Simon Gaiser <simon@invisiblethingslab.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "video-ext-client.h"
+
+#include <X11/Xlibint.h>
+#include <X11/extensions/Xext.h>
+#include <X11/extensions/extutil.h>
+
+static int close_display(Display *dpy, XExtCodes *codes);
+static Bool wire_to_event(Display *dpy, XEvent *libEv, xEvent *wireEv);
+
+static XExtensionHooks ext_hooks = {
+    NULL,          // create_gc
+    NULL,          // copy_gc
+    NULL,          // flush_gc
+    NULL,          // free_gc
+    NULL,          // create_font
+    NULL,          // free_font
+    close_display, // close_display
+    wire_to_event, // wire_to_event
+    NULL,          // event_to_wire (we don't need SendEvent)
+    NULL,          // error
+    NULL,          // error_string
+};
+
+static XExtensionInfo _ext_info;
+static XExtensionInfo *ext_info = &_ext_info;
+static const char * ext_name = QVE_NAME;
+
+#define QVECheckExtension(dpy, info, val) \
+    XextCheckExtension(dpy, info, ext_name, val)
+
+static XEXT_GENERATE_FIND_DISPLAY(find_display,
+                                  ext_info,
+                                  ext_name,
+                                  &ext_hooks,
+                                  QVENumberEvents,
+                                  NULL);
+
+static XEXT_GENERATE_CLOSE_DISPLAY(close_display, ext_info);
+
+static Bool
+wire_to_event(Display *dpy, XEvent *libEv, xEvent *wireEv)
+{
+    XExtDisplayInfo *info = find_display(dpy);
+
+    QVECheckExtension(dpy, info, False);
+
+    BYTE type = wireEv->u.u.type;
+    if ((type & 0x7f) != info->codes->first_event + QVEWindowRealized) {
+        return False;
+    }
+
+    XQVEWindowRealizedEvent *qLibEv = (XQVEWindowRealizedEvent *)libEv;
+    xQVEWindowRealizedEvent *qWireEv = (xQVEWindowRealizedEvent *)wireEv;
+
+    qLibEv->type = type & 0x7f;
+    qLibEv->serial = _XSetLastRequestRead(dpy, (xGenericReply *)wireEv);
+    qLibEv->send_event = (type & 0x80) != 0;
+    qLibEv->display = dpy;
+    qLibEv->window = qWireEv->window;
+    qLibEv->unrealized =
+        (qWireEv->detail & QVEWindowRealizedDetailUnrealized) != 0;
+
+    return True;
+}
+
+Bool
+XQVEQueryExtension(Display *dpy, int *event_base)
+{
+    XExtDisplayInfo *info = find_display(dpy);
+
+    if (!XextHasExtension(info)) {
+        return False;
+    }
+
+    *event_base = info->codes->first_event;
+    return True;
+}
+
+Bool
+XQVERegister(Display *dpy)
+{
+    XExtDisplayInfo *info = find_display(dpy);
+
+    QVECheckExtension(dpy, info, False);
+
+    LockDisplay(dpy);
+    xQVEReq *req;
+#define X_QVE X_QVERegister
+    GetReq(QVE, req);
+#undef X_QVE
+    req->reqType = info->codes->major_opcode;
+    req->QVEReqType = X_QVERegister;
+    UnlockDisplay(dpy);
+    SyncHandle();
+
+    return True;
+}

--- a/gui-agent/video-ext-client.h
+++ b/gui-agent/video-ext-client.h
@@ -1,0 +1,36 @@
+/*
+ * The Qubes OS Project, https://www.qubes-os.org/
+ *
+ * Copyright (C) 2025  Simon Gaiser <simon@invisiblethingslab.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include "qubes-video-ext.h"
+#include <X11/Xlib.h>
+
+typedef struct {
+    int type;
+    unsigned long serial;
+    Bool send_event;
+    Display *display;
+    Window window;
+    Bool unrealized;
+} XQVEWindowRealizedEvent;
+
+Bool XQVERegister(Display *dpy);
+Bool XQVEQueryExtension(Display *dpy, int *event_base);

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -52,6 +52,7 @@
 #include "error.h"
 #include "encoding.h"
 #include "unix-addr.h"
+#include "video-ext-client.h"
 #include <libvchan.h>
 #include <poll.h>
 #include "unistr.h"
@@ -92,6 +93,7 @@
 
 static int damage_event, damage_error;
 static int xfixes_event, xfixes_error;
+static int qve_event;
 /* from gui-common/error.c */
 extern int print_x11_errors;
 
@@ -148,7 +150,8 @@ struct window_data {
     int input_hint; /* the window should get input focus - False=Never */
     int support_delete_window;
     int support_take_focus;
-    int window_dump_pending; /* send MSG_WINDOW_DUMP at next damage notification */
+    int realized;
+    int input_only;
 };
 
 struct embeder_data {
@@ -346,7 +349,8 @@ static void send_event(Ghandles * g, const struct input_event *iev) {
 static void send_wmname(Ghandles * g, XID window);
 static void send_wmnormalhints(Ghandles * g, XID window, int ignore_fail);
 static void send_wmclass(Ghandles * g, XID window, int ignore_fail);
-static void send_pixmap_grant_refs(Ghandles * g, XID window);
+static void send_pixmap_grant_refs(Ghandles * g, XID window,
+                                   struct window_data * wd);
 static void retrieve_wmhints(Ghandles * g, XID window, int ignore_fail);
 static void retrieve_wmprotocols(Ghandles * g, XID window, int ignore_fail);
 
@@ -355,18 +359,9 @@ static void process_xevent_damage(Ghandles * g, XID window,
 {
     struct msg_shmimage mx;
     struct msg_hdr hdr;
-    struct genlist *l;
-    struct window_data *wd;
 
-    l = lookup_window(g, windows_list, window, __func__);
-    if (!l)
+    if (!lookup_window(g, windows_list, window, __func__))
         return;
-    wd = l->data;
-
-    if (wd->window_dump_pending) {
-        send_pixmap_grant_refs(g, window);
-        wd->window_dump_pending = False;
-    }
 
     hdr.type = MSG_SHMIMAGE;
     hdr.window = window;
@@ -375,6 +370,26 @@ static void process_xevent_damage(Ghandles * g, XID window,
     mx.width = width;
     mx.height = height;
     write_message(g->vchan, hdr, mx);
+}
+
+static void process_xevent_realized(Ghandles *g, XQVEWindowRealizedEvent *ev)
+{
+    struct genlist *l;
+    struct window_data *wd;
+
+    l = lookup_window(g, windows_list, ev->window, __func__);
+    if (!l) {
+        return;
+    }
+    wd = l->data;
+
+    wd->realized = !ev->unrealized;
+
+    if (g->log_level > 1) {
+        fprintf(stderr, "window 0x%lx realized=%d\n", ev->window, wd->realized);
+    }
+
+    send_pixmap_grant_refs(g, ev->window, wd);
 }
 
 static void send_cursor(Ghandles *g, XID window, uint32_t cursor)
@@ -490,14 +505,15 @@ static void process_xevent_createnotify(Ghandles * g, XCreateWindowEvent * ev)
     wd->input_hint = True;
     wd->support_delete_window = False;
     wd->support_take_focus = False;
-    wd->window_dump_pending = False;
+    wd->realized = False;
+    wd->input_only = attr.class == InputOnly;
     list_insert(windows_list, ev->window, wd);
 
     if (attr.border_width > 0) {
         XSetWindowBorderWidth(g->display, ev->window, 0);
     }
 
-    if (attr.class != InputOnly)
+    if (!wd->input_only)
         XDamageCreate(g->display, ev->window,
                 XDamageReportRawRectangles);
     // the following hopefully avoids missed damage events
@@ -539,13 +555,19 @@ static void feed_xdriver(Ghandles * g, int type, int arg1, int arg2)
     }
 }
 
-void send_pixmap_grant_refs(Ghandles * g, XID window)
+static void send_pixmap_grant_refs(Ghandles * g, XID window,
+                                   struct window_data * wd)
 {
     struct msg_hdr hdr;
     uint8_t *wd_msg_buf;
     size_t wd_msg_len;
     size_t rcvd;
     int ret;
+
+    if (wd->input_only || !wd->realized) {
+        // see comment in dump_window_grant_refs in the input driver
+        return;
+    }
 
     feed_xdriver(g, 'W', (int) window, 0);
     if (read(g->xserver_fd, &wd_msg_len, sizeof(wd_msg_len)) != sizeof(wd_msg_len))
@@ -897,18 +919,13 @@ static void process_xevent_map(Ghandles * g, XID window)
     struct msg_hdr hdr;
     struct msg_map_info map_info;
     Window transient;
-    struct genlist *l;
-    struct window_data *wd;
 
-    l = lookup_window(g, windows_list, window, __func__);
-    if (!l) {
+    if (!lookup_window(g, windows_list, window, __func__)) {
         return;
     }
-    wd = l->data;
 
     if (g->log_level > 1)
         fprintf(stderr, "MAP for window 0x%lx\n", window);
-    wd->window_dump_pending = True;
     send_window_state(g, window);
     XGetWindowAttributes(g->display, window, &attr);
     if (XGetTransientForHint(g->display, window, &transient))
@@ -986,21 +1003,27 @@ static void process_xevent_configure(Ghandles * g, XID window,
     struct msg_configure conf;
     struct genlist *l;
     struct window_data *wd = NULL;
+    struct window_data *wd_msg;
 
     l = lookup_window(g, windows_list, window, NULL);
     if (l) {
         wd = l->data;
+        wd_msg = wd;
     } else {
         /* if not real managed window, check if this is embeder for another window */
         struct genlist *e = lookup_window(g, embeder_list, window, NULL);
         if (e) {
+            struct genlist *i;
             window = ((struct embeder_data*)e->data)->icon_window;
-            if (!list_lookup(windows_list, window))
-                /* probably icon window have just destroyed, so ignore message */
+            i = lookup_window(g, windows_list, window, NULL);
+            if (!i)
+                /* probably icon window has just been destroyed, so ignore
+                 * message */
                 return;
             /* l and wd not updated intentionally - when configure notify comes
              * from the embeder, it should be passed to dom0 (in most cases as
              * ACK for earlier configure request) */
+            wd_msg = i->data;
         } else {
             /* ignore not managed windows */
             log_unmanaged_window(g, __func__, window);
@@ -1044,7 +1067,7 @@ static void process_xevent_configure(Ghandles * g, XID window,
     conf.height = ev->height;
     conf.override_redirect = ev->override_redirect;
     write_message(g->vchan, hdr, conf);
-    send_pixmap_grant_refs(g, window);
+    send_pixmap_grant_refs(g, window, wd_msg);
 }
 
 static void send_clipboard_data(libvchan_t *vchan, XID window, char *data, uint32_t len, int protocol_version)
@@ -1467,6 +1490,10 @@ static void process_xevent(Ghandles * g)
                 process_xevent_cursor(
                     g,
                     (XFixesCursorNotifyEvent *) &event_buffer);
+            } else if (event_buffer.type == (qve_event + QVEWindowRealized)) {
+                process_xevent_realized(
+                        g,
+                        (XQVEWindowRealizedEvent *)&event_buffer);
             } else if (g->log_level > 1) {
                 fprintf(stderr,
                         "%s: unhandled event of type %d\n",
@@ -1544,7 +1571,22 @@ static int send_full_window_info(Ghandles *g, XID w, struct window_data *wd)
     conf.height = attr.height;
     conf.override_redirect = attr.override_redirect;
     write_message(g->vchan, hdr, conf);
-    send_pixmap_grant_refs(g, w);
+
+    int realized = attr.map_state == IsViewable;
+    if (realized != wd->realized) {
+        fprintf(stderr, "Error: Internal \"realized\" state does not match "
+                        "X server state\n");
+        wd->realized = realized;
+    }
+
+    int input_only = attr.class == InputOnly;
+    if (input_only != wd->input_only) {
+        fprintf(stderr, "Error: Internal \"input_only\" state does not match "
+                        "X server state\n");
+        wd->input_only = input_only;
+    }
+
+    send_pixmap_grant_refs(g, w, wd);
 
     send_wmclass(g, w, 1);
     send_wmnormalhints(g, w, 1);
@@ -2613,6 +2655,16 @@ int main(int argc, char **argv)
     if (!XDamageQueryExtension(g.display, &damage_event,
                 &damage_error)) {
         perror("XDamageQueryExtension");
+        exit(1);
+    }
+
+    if (!XQVEQueryExtension(g.display, &qve_event)) {
+        fprintf(stderr, QVE_NAME " is not available\n");
+        exit(1);
+    }
+
+    if (!XQVERegister(g.display)) {
+        fprintf(stderr, "Failed to register with " QVE_NAME "\n");
         exit(1);
     }
 

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -1548,7 +1548,7 @@ static void wait_for_unix_socket(Ghandles *g)
         else
             prev_umask=umask(0000);
         if (bind(g->xserver_listen_fd, (struct sockaddr *)&sockname, addrlen) == -1) {
-            printf("bind() failed\n");
+            fprintf(stderr, "bind() failed\n");
             close(g->xserver_listen_fd);
             exit(1);
         }

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -482,7 +482,7 @@ static void process_xevent_createnotify(Ghandles * g, XCreateWindowEvent * ev)
     /* Initialize window_data structure */
     wd = (struct window_data*)malloc(sizeof(struct window_data));
     if (!wd) {
-        fprintf(stderr, "OUT OF MEMORY\n");
+        fprintf(stderr, "%s: OUT OF MEMORY\n", __func__);
         return;
     }
     /* Default values for window_data. By default, window should receive InputFocus events */
@@ -1318,11 +1318,11 @@ static void process_xevent_message(Ghandles * g, XClientMessageEvent * ev)
                             g->screen));
                 wd->is_docked=True;
                 if (g->log_level > 1)
-                    fprintf(stderr, " created embeder 0x%lx\n", wd->embeder);
+                    fprintf(stderr, "created embeder 0x%lx\n", wd->embeder);
                 XSelectInput(g->display, wd->embeder, SubstructureNotifyMask);
                 ed = (struct embeder_data*)malloc(sizeof(struct embeder_data));
                 if (!ed) {
-                    fprintf(stderr, "OUT OF MEMORY\n");
+                    fprintf(stderr, "%s: OUT OF MEMORY\n", __func__);
                     return;
                 }
                 ed->icon_window = w;
@@ -1446,22 +1446,28 @@ static void process_xevent(Ghandles * g)
             if (event_buffer.type == (damage_event + XDamageNotify)) {
                 dev = (XDamageNotifyEvent *) & event_buffer;
                 g->time = dev->timestamp;
-                //      fprintf(stderr, "x=%hd y=%hd gx=%hd gy=%hd w=%hd h=%hd\n",
-                //        dev->area.x, dev->area.y, dev->geometry.x, dev->geometry.y, dev->area.width, dev->area.height); 
+                if (g->log_level > 1) {
+                      fprintf(stderr,
+                              "DamageNotify x=%hd y=%hd gx=%hd gy=%hd w=%hd h=%hd\n",
+                              dev->area.x, dev->area.y,
+                              dev->geometry.x, dev->geometry.y,
+                              dev->area.width, dev->area.height);
+                }
                 process_xevent_damage(g, dev->drawable,
                         dev->area.x,
                         dev->area.y,
                         dev->area.width,
                         dev->area.height);
-                //                      fprintf(stderr, "@");
             } else if (event_buffer.type == (xfixes_event + XFixesCursorNotify)) {
                 process_xevent_cursor(
                     g,
                     (XFixesCursorNotifyEvent *) &event_buffer);
-            } else if (g->log_level > 1)
-                fprintf(stderr, "#");
+            } else if (g->log_level > 1) {
+                fprintf(stderr,
+                        "%s: unhandled event of type %d\n",
+                        __func__, event_buffer.type);
+            }
     }
-
 }
 
 /* return 1 if info sent, 0 otherwise */

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -1650,7 +1650,7 @@ static void mkghandles(Ghandles * g)
 
     g->xserver_listen_fd = -1;
     g->xserver_fd = -1;
-    wait_for_unix_socket(g);	// wait for Xorg qubes_drv to connect to us
+    wait_for_unix_socket(g); // wait for Xorg qubes_drv to connect to us
     do {
         g->display = XOpenDisplay(NULL);
         if (!g->display && errno != EAGAIN) {
@@ -1661,8 +1661,8 @@ static void mkghandles(Ghandles * g)
     if (g->log_level > 0)
         fprintf(stderr,
                 "Connection to local X server established.\n");
-    g->screen = DefaultScreen(g->display);	/* get CRT id number */
-    g->root_win = RootWindow(g->display, g->screen);	/* get default attributes */
+    g->screen = DefaultScreen(g->display); /* get CRT id number */
+    g->root_win = RootWindow(g->display, g->screen); /* get default attributes */
     g->context = XCreateGC(g->display, g->root_win, 0, NULL);
     g->stub_win = XCreateSimpleWindow(g->display, g->root_win,
             0, 0, 1, 1,

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -329,11 +329,11 @@ static void send_event(Ghandles * g, const struct input_event *iev) {
         }
         g->created_input_device = 0;
     }
-    
+
     // send syn
     const struct input_event syn = {.type = EV_SYN, .code = 0, .value = 0};
     status = write(g->uinput_fd, &(syn), sizeof(struct input_event));
-    
+
     if ( status < 0 ) {
         if (g->log_level > 0) {
             fprintf(stderr, "writing SYN failed, falling back to xdriver. WRITE ERROR CODE: %d\n", status);
@@ -1790,7 +1790,7 @@ static void handle_keypress(Ghandles * g, XID UNUSED(winid))
                 XFreeModifiermap(modmap);
             }
         }
-        
+
         feed_xdriver(g, 'K', key.keycode, key.type == KeyPress ? 1 : 0);
     } else {
         int mod_mask;
@@ -1799,7 +1799,7 @@ static void handle_keypress(Ghandles * g, XID UNUSED(winid))
         iev.type = EV_KEY;
         XModifierKeymap *modmap;
         modmap = XGetModifierMapping(g->display);
-        
+
         if (!modmap) {
                 if (g->log_level > 0)
                     fprintf(stderr, "failed to get modifier mapping\n");
@@ -1833,7 +1833,7 @@ static void handle_keypress(Ghandles * g, XID UNUSED(winid))
                         // update state for this modifier
                         g->last_known_modifier_states ^= mod_mask;
                     }
-                    
+
                     // last modifier state was up, modifier has since been pressed down
                     else if (!(g->last_known_modifier_states & mod_mask) && (key.state & mod_mask)) {
                         iev.code = modmap->modifiermap[mod_index*modmap->max_keypermod] - 8;
@@ -1846,7 +1846,7 @@ static void handle_keypress(Ghandles * g, XID UNUSED(winid))
                 }
             }
         }
-        
+
         XFreeModifiermap(modmap);
 
         // caps lock needs to be excluded to not send down, up, down or down, up, up on a caps lock sync instead of down, up
@@ -1855,7 +1855,7 @@ static void handle_keypress(Ghandles * g, XID UNUSED(winid))
             iev.value = (key.type == KeyPress ? 1 : 0);
             send_event(g, &iev);
         }
-        
+
     }
 }
 
@@ -2501,17 +2501,17 @@ int main(int argc, char **argv)
         g.uinput_fd = open("/dev/uinput", O_WRONLY | O_NDELAY);
         if(g.uinput_fd < 0) {
             g.uinput_fd = open("/dev/input/uinput", O_WRONLY | O_NDELAY);
-            
+
             if(g.uinput_fd < 0) {
                 fprintf(stderr, "Couldn't open uinput, falling back to xdriver\n");
                 g.created_input_device = 0;
             }
         }
     }
-    
+
     // input device creation
     if(g.created_input_device) {
-        
+
         if (ioctl(g.uinput_fd, UI_SET_EVBIT, EV_SYN) < 0) {
             fprintf(stderr, "error setting EVBIT for EV_SYN, falling back to xdriver\n");
             g.created_input_device = 0;
@@ -2528,22 +2528,22 @@ int main(int argc, char **argv)
                 fprintf(stderr, "Not able to set KEYBIT %d\n", i);
             }
         }
-        
+
         struct uinput_setup usetup;
         memset(&usetup, 0, sizeof(usetup));
         strcpy(usetup.name, "Qubes Virtual Input Device");
-        
+
         if(ioctl(g.uinput_fd, UI_DEV_SETUP, &usetup) < 0) {
             fprintf(stderr, "Input device setup failed, falling back to xdriver\n");
             g.created_input_device = 0;
         } else {
-            
+
             if(ioctl(g.uinput_fd, UI_DEV_CREATE) < 0) {
                 fprintf(stderr, "Input device creation failed, falling back to xdriver\n");
                 g.created_input_device = 0;
             }
         }
-        
+
         g.last_known_modifier_states = 0;
     }
 

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -699,9 +699,11 @@ void send_wmname(Ghandles * g, XID window)
     write_message(g->vchan, hdr, msg);
 }
 
-/*	Retrieve the supported WM Protocols
-    We don't forward the info to dom0 as we only need specific client protocols
-    */
+/*
+ * Retrieve the supported WM Protocols
+ *
+ * We don't forward the info to dom0 as we only need specific client protocols.
+ */
 void retrieve_wmprotocols(Ghandles * g, XID window, int ignore_fail)
 {
     int nitems;
@@ -739,9 +741,12 @@ void retrieve_wmprotocols(Ghandles * g, XID window, int ignore_fail)
 }
 
 
-/* 	Retrieve the 'real' WMHints.
-    We don't forward the info to dom0 as we only need InputHint and dom0 doesn't care about it
-    */
+/*
+ * Retrieve the 'real' WMHints
+ *
+ * We don't forward the info to dom0 as we only need InputHint and dom0 doesn't
+ * care about it.
+ */
 void retrieve_wmhints(Ghandles * g, XID window, int ignore_fail)
 {
     XWMHints *wm_hints;

--- a/include/qubes-video-ext.h
+++ b/include/qubes-video-ext.h
@@ -1,0 +1,64 @@
+/*
+ * The Qubes OS Project, https://www.qubes-os.org/
+ *
+ * Copyright (C) 2025  Simon Gaiser <simon@invisiblethingslab.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <X11/Xproto.h>
+#include <assert.h>
+
+// This X extension is only for internal use. It's used to send custom events
+// from the video driver to the agent. Since video driver and agent are updated
+// in lockstep we don't need any version handling.
+
+#define QVE_NAME "_qubes-video-ext"
+
+#define X_QVERegister 0
+#define X_QVEUnregister 1
+#define XQVENumberRequests 2
+
+#define QVEWindowRealized 0
+#define QVENumberEvents 1
+
+typedef struct {
+    CARD8 reqType;
+    CARD8 QVEReqType;
+    CARD16 length;
+} xQVEReq;
+
+#define sz_xQVEReq sizeof(xQVEReq)
+
+static_assert(sizeof(xQVEReq) >= sizeof(xReq));
+
+#define QVEWindowRealizedDetailUnrealized 1
+
+typedef struct {
+    BYTE type;
+    BYTE detail;
+    CARD16 sequenceNumber;
+    CARD32 window;
+    CARD32 pad1;
+    CARD32 pad2;
+    CARD32 pad3;
+    CARD32 pad4;
+    CARD32 pad5;
+    CARD32 pad6;
+} xQVEWindowRealizedEvent;
+
+static_assert(sizeof(xQVEWindowRealizedEvent) == sizeof(xEvent));

--- a/include/unix-addr.h
+++ b/include/unix-addr.h
@@ -1,0 +1,37 @@
+/*
+ * The Qubes OS Project, https://www.qubes-os.org/
+ *
+ * Copyright (C) 2025  Simon Gaiser <simon@invisiblethingslab.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <sys/un.h>
+
+static inline socklen_t sockaddr_un_from_path(struct sockaddr_un *addr, char *path)
+{
+    size_t len;
+
+    memset(addr, 0, sizeof(*addr));
+    addr->sun_family = AF_UNIX;
+    len = strlen(path);
+    if (len == 0 || len > sizeof(addr->sun_path) - 1) {
+        return 0;
+    }
+    memcpy(addr->sun_path, path, len);
+    return offsetof(typeof(*addr), sun_path) + len + 1;
+}

--- a/xf86-input-mfndev/src/qubes.c
+++ b/xf86-input-mfndev/src/qubes.c
@@ -604,12 +604,41 @@ static void dump_window_grant_refs(int window_id, int fd)
         // the window is destroyed before the driver sees the req
         goto send_response;
 
+    if (x_window->drawable.class == InputOnly) {
+        // Composite redirect doesn't handle InputOnly windows. There should be
+        // nothing to display anyway.
+        xf86Msg(X_ERROR, "can't dump InputOnly windows 0x%x\n", window_id);
+        goto send_response;
+    }
+
+    if (!x_window->realized) {
+        // Composite redirect is setup/teared-down during Realize-/Unrealize-
+        // Window (called when a window gets mapped/unmapped). So if the window
+        // is not realized we don't have a per window pixmap we can send.
+        //
+        // Note that the map notification is sent before calling RealizeWindow.
+        // Therefore our video driver sends the agent a custom event when the
+        // window has actually been realized.
+        //
+        // This means that the configure of a window before realization will
+        // not send grants. This should be fine since we will send grants when
+        // it's realized and it needs to redraw on expose anyway.
+        //
+        // We can get here in a race when a window is being unrealized and/or
+        // destroyed, as described above for the window lookup. So we might
+        // have to improve or silence this error message in the furture.
+        xf86Msg(X_ERROR, "can't dump not realized window 0x%x\n", window_id);
+        goto send_response;
+    }
+
     screen = x_window->drawable.pScreen;
     pixmap = (*screen->GetWindowPixmap) (x_window);
 
     priv = xf86_qubes_pixmap_get_private(pixmap);
     if (priv == NULL) {
-        xf86Msg(X_ERROR, "can't dump window without grant table allocation\n");
+        xf86Msg(X_ERROR,
+                "can't dump window 0x%x without grant table allocation\n",
+                window_id);
         goto send_response;
     }
 

--- a/xf86-video-dummy/src/dummy_driver.c
+++ b/xf86-video-dummy/src/dummy_driver.c
@@ -137,8 +137,8 @@ _X_EXPORT DriverRec DUMMY = {
 };
 
 static SymTabRec DUMMYChipsets[] = {
-    { DUMMY_CHIP,   "dummy" },
-    { -1,		 NULL }
+    { DUMMY_CHIP, "dummy" },
+    { -1,         NULL }
 };
 
 typedef enum {
@@ -148,10 +148,10 @@ typedef enum {
 } DUMMYOpts;
 
 static const OptionInfoRec DUMMYOptions[] = {
-    { OPTION_SW_CURSOR,	"SWcursor",	OPTV_BOOLEAN,	{0}, FALSE },
-    { OPTION_RENDER,	"Render",	OPTV_STRING,	{0}, FALSE },
+    { OPTION_SW_CURSOR, "SWcursor",     OPTV_BOOLEAN,   {0}, FALSE },
+    { OPTION_RENDER,    "Render",       OPTV_STRING,    {0}, FALSE },
     { OPTION_GUI_DOMID, "GUIDomID",     OPTV_INTEGER,   {0}, FALSE },
-    { -1,                  NULL,           OPTV_NONE,	{0}, FALSE }
+    { -1,                  NULL,           OPTV_NONE,   {0}, FALSE }
 };
 
 #ifdef XFree86LOADER
@@ -718,7 +718,7 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
     clockRanges->ClockMulFactor = 1;
     clockRanges->minClock = 11000;   /* guessed §§§ */
     clockRanges->maxClock = maxClock;
-    clockRanges->clockIndex = -1;		/* programmable */
+    clockRanges->clockIndex = -1; /* programmable */
     clockRanges->interlaceAllowed = TRUE;
     clockRanges->doubleScanAllowed = TRUE;
 

--- a/xf86-video-dummy/src/dummy_driver.c
+++ b/xf86-video-dummy/src/dummy_driver.c
@@ -56,6 +56,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include "../../include/list.h"
+#include "../../include/qubes-video-ext.h"
 
 /* Mandatory functions */
 static const OptionInfoRec *DUMMYAvailableOptions(int chipid, int busid);
@@ -105,6 +106,11 @@ static Bool     dummyDriverFunc(ScrnInfoPtr pScrn, xorgDriverFuncOp op,
 #define DUMMY_MAX_HEIGHT 32767
 
 static ScrnInfoPtr DUMMYScrn; /* static-globalize it */
+
+static ClientPtr agentClient;
+
+static ExtensionEntry *QVE;
+
 
 /*
  * This is intentionally screen-independent.  It indicates the binding
@@ -471,6 +477,43 @@ Bool DUMMYAdjustScreenPixmap(ScrnInfoPtr pScrn, int width, int height)
  */
 _X_EXPORT XF86ModuleData dummyqbsModuleData = { &dummyVersRec, dummySetup, NULL };
 
+static int
+QVEDispatch(ClientPtr client)
+{
+    REQUEST(xQVEReq);
+    REQUEST_SIZE_MATCH(xQVEReq);
+    switch (stuff->QVEReqType) {
+        case X_QVERegister:
+            agentClient = client;
+            return Success;
+        case X_QVEUnregister:
+            if (agentClient == client) {
+                agentClient = NULL;
+            }
+            return Success;
+        default:
+            return BadRequest;
+    }
+}
+
+static int
+QVEDispatchSwapped(ClientPtr client)
+{
+    xf86Msg(X_ERROR, QVE_NAME " doesn't support swapped clients\n");
+    return BadRequest;
+}
+
+static void
+QubesClientStateCallback(CallbackListPtr *cbl, void *cb_private, void *data)
+{
+    NewClientInfoRec *clientinfo = data;
+    ClientPtr client = clientinfo->client;
+
+    if (client == agentClient && client->clientState == ClientStateGone) {
+        agentClient = NULL;
+    }
+}
+
 static pointer
 dummySetup(pointer module, pointer opts, int *errmaj, int *errmin)
 {
@@ -484,6 +527,30 @@ dummySetup(pointer module, pointer opts, int *errmaj, int *errmin)
          * Modules that this driver always requires can be loaded here
          * by calling LoadSubModule().
          */
+
+        if (!AddCallback(&ClientStateCallback, QubesClientStateCallback, NULL)) {
+            xf86Msg(X_ERROR, "Failed to register ClientStateCallback\n");
+            if (errmaj) {
+                *errmaj = LDR_MODSPECIFIC;
+            }
+            return NULL;
+        }
+
+        QVE = AddExtension(QVE_NAME,
+                               QVENumberEvents,
+                               0 /* number of errors */,
+                               QVEDispatch,
+                               QVEDispatchSwapped,
+                               NULL /* CloseDownProc */,
+                               StandardMinorOpcode);
+        if (QVE == NULL) {
+            xf86Msg(X_ERROR, "Failed to register " QVE_NAME " extentions\n");
+            if (errmaj) {
+                *errmaj = LDR_MODSPECIFIC;
+            }
+            return NULL;
+        }
+        EventSwapVector[QVE->eventBase + QVEWindowRealized] = NotImplemented;
 
         /*
          * The return value must be non-NULL on success even though there
@@ -1024,6 +1091,34 @@ qubes_destroy_pixmap(PixmapPtr pixmap) {
     return fbDestroyPixmap(pixmap);
 }
 
+static void
+sendRealizedNotify(WindowPtr win, Bool unrealized) {
+    if (agentClient) {
+        xQVEWindowRealizedEvent e = {};
+        e.type = QVE->eventBase + QVEWindowRealized;
+
+        if (unrealized) {
+            e.detail |= QVEWindowRealizedDetailUnrealized;
+        }
+
+        e.window = win->drawable.id;
+
+        WriteEventsToClient(agentClient, 1, (xEvent *)&e);
+    }
+}
+
+static Bool
+qubesRealizeWindow(WindowPtr win) {
+    sendRealizedNotify(win, FALSE);
+    return TRUE;
+}
+
+static Bool
+qubesUnrealizeWindow(WindowPtr win) {
+    sendRealizedNotify(win, TRUE);
+    return TRUE;
+}
+
 /* Mandatory */
 static Bool
 DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
@@ -1156,6 +1251,8 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
 
     pScreen->CreatePixmap = qubes_create_pixmap;
     pScreen->DestroyPixmap = qubes_destroy_pixmap;
+    pScreen->RealizeWindow = qubesRealizeWindow;
+    pScreen->UnrealizeWindow = qubesUnrealizeWindow;
     PictureScreenPtr ps = GetPictureScreenIfSet(pScreen);
     ps->Glyphs = fbGlyphs;
     dPtr->CreateScreenResources = pScreen->CreateScreenResources;

--- a/xf86-video-dummy/src/dummy_driver.c
+++ b/xf86-video-dummy/src/dummy_driver.c
@@ -568,7 +568,7 @@ DUMMYProbe(DriverPtr drv, int flags)
 
         for (i = 0; i < numUsed; i++) {
             ScrnInfoPtr pScrn = NULL;
-            int entityIndex = 
+            int entityIndex =
                 xf86ClaimNoSlot(drv,DUMMY_CHIP,devSections[i],TRUE);
             /* Allocate a ScrnInfoRec and claim the slot */
             if ((pScrn = xf86AllocateScreen(drv,0 ))) {
@@ -589,7 +589,7 @@ DUMMYProbe(DriverPtr drv, int flags)
                 foundScreen = TRUE;
             }
         }
-    }    
+    }
     return foundScreen;
 }
 
@@ -609,21 +609,21 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
     GDevPtr device = xf86GetEntityInfo(pScrn->entityList[0])->device;
     const char *render, *defaultRender = "/dev/dri/renderD128";
 
-    if (flags & PROBE_DETECT) 
+    if (flags & PROBE_DETECT)
         return TRUE;
-    
+
     /* Allocate the DummyRec driverPrivate */
     if (!DUMMYGetRec(pScrn)) {
         return FALSE;
     }
-    
+
     dPtr = DUMMYPTR(pScrn);
 
     pScrn->chipset = (char *)xf86TokenToString(DUMMYChipsets,
             DUMMY_CHIP);
 
     xf86DrvMsg(pScrn->scrnIndex, X_INFO, "Chipset is a DUMMY\n");
-    
+
     pScrn->monitor = pScrn->confScreen->monitor;
 
     if (!xf86SetDepthBpp(pScrn, 0, 0, 0,  Support24bppFb | Support32bppFb))
@@ -668,7 +668,7 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
         }
     }
 
-    if (!xf86SetDefaultVisual(pScrn, -1)) 
+    if (!xf86SetDefaultVisual(pScrn, -1))
         return FALSE;
 
     if (pScrn->depth > 1) {
@@ -719,7 +719,7 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
     clockRanges->minClock = 11000;   /* guessed §§§ */
     clockRanges->maxClock = maxClock;
     clockRanges->clockIndex = -1;		/* programmable */
-    clockRanges->interlaceAllowed = TRUE; 
+    clockRanges->interlaceAllowed = TRUE;
     clockRanges->doubleScanAllowed = TRUE;
 
     /* Subtract memory for HW cursor */
@@ -755,8 +755,8 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
      * driver and if the driver doesn't provide code to set them.  They
      * are not pre-initialised at all.
      */
-    xf86SetCrtcForModes(pScrn, 0); 
- 
+    xf86SetCrtcForModes(pScrn, 0);
+
     /* Set the current mode to the first in the list */
     pScrn->currentMode = pScrn->modes;
 
@@ -774,7 +774,7 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
         if (!xf86LoadSubModule(pScrn, "ramdac"))
             RETURN;
     }
-    
+
     /* We have no contiguous physical fb in physical memory */
     pScrn->memPhysBase = 0;
     pScrn->fbOffset = 0;
@@ -784,7 +784,7 @@ DUMMYPreInit(ScrnInfoPtr pScrn, int flags)
 
     if (!render)
         render = defaultRender;
- 
+
     dPtr->fd = open(render, O_RDWR);
     if (dPtr->fd < 0)
         xf86DrvMsg(pScrn->scrnIndex, X_ERROR, "Open render %s fail\n", render);
@@ -809,7 +809,7 @@ static Bool
 DUMMYEnterVT(VT_FUNC_ARGS_DECL)
 {
     SCRN_INFO_PTR(arg);
-    
+
     /* Should we re-save the text mode on each VT enter? */
     if(!dummyModeInit(pScrn, pScrn->currentMode))
       return FALSE;
@@ -843,7 +843,7 @@ DUMMYLoadPalette(
        shift = Gshift = 1;
        break;
    case 16:
-       shift = 0; 
+       shift = 0;
        Gshift = 0;
        break;
    default:
@@ -856,7 +856,7 @@ DUMMYLoadPalette(
        dPtr->colors[index].red = colors[index].red << shift;
        dPtr->colors[index].green = colors[index].green << Gshift;
        dPtr->colors[index].blue = colors[index].blue << shift;
-   } 
+   }
 
 }
 
@@ -1061,12 +1061,12 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
             return FALSE;
     }
 
-    
+
     /*
      * next we save the current state and setup the first mode
      */
     dummySave(pScrn);
-    
+
     if (!dummyModeInit(pScrn,pScrn->currentMode))
         return FALSE;
     DUMMYAdjustFrame(ADJUST_FRAME_ARGS(pScrn, pScrn->frameX0, pScrn->frameY0));
@@ -1075,9 +1075,9 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
      * Reset visual list.
      */
     miClearVisualTypes();
-    
+
     /* Setup the visuals we support. */
-    
+
     if (!miSetVisualTypes(pScrn->depth,
                 miGetDefaultVisualMask(pScrn->depth),
                 pScrn->rgbBits, pScrn->defaultVisual))
@@ -1211,7 +1211,7 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
     }
 
     /* XRANDR initialization end */
-    
+
     if (dPtr->swCursor)
         xf86DrvMsg(pScrn->scrnIndex, X_CONFIG, "Using Software Cursor.\n");
 
@@ -1225,9 +1225,9 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
         AvailFBArea.y1 = 0;
         AvailFBArea.x2 = pScrn->displayWidth;
         AvailFBArea.y2 = lines;
-        xf86InitFBManager(pScreen, &AvailFBArea); 
+        xf86InitFBManager(pScreen, &AvailFBArea);
 
-        xf86DrvMsg(pScrn->scrnIndex, X_INFO, 
+        xf86DrvMsg(pScrn->scrnIndex, X_INFO,
                 "Using %i scanlines of offscreen memory \n"
                 , lines - pScrn->virtualY);
     }
@@ -1253,8 +1253,8 @@ DUMMYScreenInit(SCREEN_INIT_ARGS_DECL)
         return FALSE;
 
     if (!xf86HandleColormaps(pScreen, 256, pScrn->rgbBits,
-                DUMMYLoadPalette, NULL, 
-                CMAP_PALETTED_TRUECOLOR 
+                DUMMYLoadPalette, NULL,
+                CMAP_PALETTED_TRUECOLOR
                 | CMAP_RELOAD_ON_MODE_SWITCH))
         return FALSE;
 
@@ -1292,7 +1292,7 @@ DUMMYSwitchMode(SWITCH_MODE_ARGS_DECL)
 DUMMYAdjustFrame(ADJUST_FRAME_ARGS_DECL)
 {
     SCRN_INFO_PTR(arg);
-    int Base; 
+    int Base;
 
     Base = (y * pScrn->displayWidth + x) >> 2;
 
@@ -1363,7 +1363,7 @@ DUMMYSaveScreen(ScreenPtr pScreen, int mode)
         dPtr = DUMMYPTR(pScrn);
 
         dPtr->screenSaver = xf86IsUnblank(mode);
-    } 
+    }
     return TRUE;
 }
 
@@ -1379,7 +1379,7 @@ dummySave(ScrnInfoPtr pScrn)
 {
 }
 
-    static void 
+    static void
 dummyRestore(ScrnInfoPtr pScrn, Bool restoreText)
 {
 }
@@ -1421,7 +1421,7 @@ DUMMYCreateWindow(WindowPtr pWin)
             VFB_PROP = MakeAtom(VFB_PROP_NAME, strlen(VFB_PROP_NAME), 1);
 
 #if GET_ABI_MAJOR(ABI_VIDEODRV_VERSION) < 21
-        ret = ChangeWindowProperty(pWinRoot, VFB_PROP, XA_STRING, 
+        ret = ChangeWindowProperty(pWinRoot, VFB_PROP, XA_STRING,
                 8, PropModeReplace, (int)4, (pointer)"TRUE", FALSE);
 #else
         ret = dixChangeWindowProperty(serverClient, pWinRoot,


### PR DESCRIPTION
We rely on composite redirect mode of the X server to get per window pixmaps. Those are setup/teared-down in compRealizeWindow/ compUnrealizeWindow (via compCheckRedirect).

So not realized windows don't have a per window pixmap. Sending grant refs for them was always broken since we didn't send the offset into the screen pixmap in those cases. But with the recent change to not allocate grant refs for the screen pixmap this leads to a noticable error message.

So don't try to send grant refs for not realized windows. This means that the configure before mapping will not contiain grant refs. But when we map the window we will get a damage event because of the new pixmap compRealizeWindow has allocated and send them then. So this should be fine.