### PR TITLE
Introduce background color parameter

### DIFF
--- a/appvm-scripts/usr/lib/qubes/qubes-gui-agent-pre.sh
+++ b/appvm-scripts/usr/lib/qubes/qubes-gui-agent-pre.sh
@@ -20,6 +20,11 @@ if [ -z "$gui_xid" ]; then
 fi
 gui_opts="-d $gui_xid"
 
+background_color="$(qubesdb-read /qubes-gui-background-color 2>/dev/null)"
+if [ -n "$background_color" ] && [ "$background_color" -gt 0 ]; then
+    gui_opts="$gui_opts -b $background_color"
+fi
+
 debug_mode=$(qubesdb-read /qubes-debug-mode 2> /dev/null)
 if [ -n "$debug_mode" ] && [ "$debug_mode" -gt 0 ]; then
     gui_opts="$gui_opts -vv"

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -132,6 +132,7 @@ typedef struct {
     int log_level;
     int sync_all_modifiers;
     int composite_redirect_automatic;
+    long background_color;
     pid_t x_pid;
     uint32_t domid;
     uint32_t protocol_version;
@@ -1272,10 +1273,7 @@ static void process_xevent_message(Ghandles * g, XClientMessageEvent * ev)
                 /* TODO: error checking */
                 wd->embeder = XCreateSimpleWindow(g->display, g->root_win,
                         0, 0, 32, 32, /* default icon size, will be changed by dom0 */
-                        0, BlackPixel(g->display,
-                            g->screen),
-                        WhitePixel(g->display,
-                            g->screen));
+                        0, g->background_color, g->background_color);
                 wd->is_docked=True;
                 if (g->log_level > 1)
                     fprintf(stderr,
@@ -2371,6 +2369,7 @@ static void usage(void)
     fprintf(stderr, "       -c  turn off composite \"redirect automatic\" mode\n");
     fprintf(stderr, "       -h  print this message\n");
     fprintf(stderr, "       -d  GUI domain id (default: 0)\n");
+    fprintf(stderr, "       -b  Background color (default: 0)\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Log levels:\n");
     fprintf(stderr, " 0 - only errors\n");
@@ -2387,7 +2386,8 @@ static void parse_args(Ghandles * g, int argc, char **argv)
     g->sync_all_modifiers = 1;
     g->composite_redirect_automatic = 1;
     g->domid = 0;
-    while ((opt = getopt(argc, argv, "qvchmMd:")) != -1) {
+    g->background_color = 0xFFFFFFFF;
+    while ((opt = getopt(argc, argv, "qvchmMd:b:")) != -1) {
         switch (opt) {
             case 'q':
                 g->log_level--;
@@ -2409,6 +2409,9 @@ static void parse_args(Ghandles * g, int argc, char **argv)
                 exit(0);
             case 'd':
                 g->domid = atoi(optarg);
+                break;
+            case 'b':
+                g->background_color = atol(optarg);
                 break;
             default:
                 usage();


### PR DESCRIPTION
Introduces a background color parameter (-b) alongside the qubesdb property /qubes-gui-background-color in order to allow the background color of windows (i.e. trayicons) to be set from dom0. Mitigates https://github.com/QubesOS/qubes-issues/issues/2846