### PR TITLE
Delay connecting with gui-daemon until after starting Xorg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,8 @@ install-common:
 	install -d $(DESTDIR)/etc/qubes/post-install.d
 	install -m 0755 appvm-scripts/etc/qubes/post-install.d/20-qubes-guivm-gui-agent.sh \
                 $(DESTDIR)/etc/qubes/post-install.d/20-qubes-guivm-gui-agent.sh
+	install -m 0755 appvm-scripts/etc/qubes/post-install.d/20-qubes-gui-agent.sh \
+                $(DESTDIR)/etc/qubes/post-install.d/20-qubes-gui-agent.sh
 	install -D appvm-scripts/usrbin/qubes-session \
 		$(DESTDIR)/usr/bin/qubes-session
 	install -D appvm-scripts/usrbin/qubes-run-xorg \

--- a/appvm-scripts/etc/qubes/post-install.d/20-qubes-gui-agent.sh
+++ b/appvm-scripts/etc/qubes/post-install.d/20-qubes-gui-agent.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# announce support for late gui-daemon connection
+qvm-features-request supported-feature.late-gui-daemon=1

--- a/appvm-scripts/usrbin/qubes-run-xorg
+++ b/appvm-scripts/usrbin/qubes-run-xorg
@@ -26,7 +26,14 @@
 
 ## This script is triggered by qubes-gui-agent systemd service.
 
-#expects W, H, MEM and DEPTH env vars to be set by invoker
+#expects W, H, MEM and DEPTH env vars to be set by invoker, but use default
+# values if they aren't
+
+[ -n "$W" ] || W=1920
+[ -n "$H" ] || H=1080
+[ -n "$MEM" ] || MEM=$(( W * H * 4 / 1024 ))
+[ -n "$DEPTH" ] || DEPTH=24
+
 DUMMY_MAX_CLOCK=300 #hardcoded in dummy_drv
 PREFERRED_HSYNC=50
 RES="$W"x"$H"

--- a/debian/qubes-gui-agent.install
+++ b/debian/qubes-gui-agent.install
@@ -10,6 +10,7 @@ etc/security/limits.d/90-qubes-gui.conf
 etc/qubes-rpc/qubes.SetMonitorLayout
 etc/qubes-rpc/qubes.GuiVMSession
 etc/qubes/post-install.d/20-qubes-guivm-gui-agent.sh
+etc/qubes/post-install.d/20-qubes-gui-agent.sh
 etc/xdg/autostart/qubes-gtk4-workarounds.desktop
 etc/xdg/autostart/qubes-icon-sender.desktop
 etc/xdg/autostart/qubes-qrexec-fork-server.desktop

--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -73,6 +73,8 @@
     }) + sizeof(x)/sizeof((x)[0]))
 #define SOCKET_ADDRESS  "/var/run/xf86-qubes-socket"
 
+#define STATUS_FILE_PATH  "/run/qubes/gui-agent.status"
+
 /* Supported protocol version */
 
 #define PROTOCOL_VERSION_MAJOR 1
@@ -2392,6 +2394,31 @@ static void handshake(Ghandles *g)
     read_struct(g->vchan, xconf);
 }
 
+static void write_status_file(const char *status)
+{
+    int fd = open(STATUS_FILE_PATH, O_CREAT | O_WRONLY | O_NOFOLLOW | O_TRUNC, 0644);
+    if (fd < 0) {
+        perror("open status file");
+        return;
+    }
+    FILE *f = fdopen(fd, "w");
+    if (!f) {
+        perror("fdopen status file");
+        close(fd);
+        return;
+    }
+    if (fwrite(status, strlen(status), 1, f) != 1) {
+        perror("write error");
+    }
+    fclose(f);
+    close(fd);
+}
+
+static void cleanup_status_file(void)
+{
+    unlink(STATUS_FILE_PATH);
+}
+
 static void handle_guid_disconnect(void)
 {
     Ghandles *g = ghandles_for_vchan_reinitialize;
@@ -2401,6 +2428,7 @@ static void handle_guid_disconnect(void)
                 "cannot reconnect, exiting!\n");
         exit(1);
     }
+    write_status_file("started\n");
     libvchan_close(g->vchan);
     g->vchan = libvchan_server_init(g->domid, 6000, 4096, 4096);
     /* wait for gui daemon */
@@ -2408,6 +2436,7 @@ static void handle_guid_disconnect(void)
         libvchan_wait(g->vchan);
     handshake(g);
     send_all_windows_info(g);
+    write_status_file("connected\n");
 }
 
 static _Noreturn void handle_sigterm(int UNUSED(sig),
@@ -2498,6 +2527,9 @@ int main(int argc, char **argv)
     int xfd;
     Ghandles g = { .x_pid = -1 };
 
+    write_status_file("starting\n");
+    atexit(cleanup_status_file);
+
     g.created_input_device = access("/run/qubes-service/gui-agent-virtual-input-device", F_OK) == 0;
 
     if(g.created_input_device) {
@@ -2550,7 +2582,6 @@ int main(int argc, char **argv)
 
         g.last_known_modifier_states = 0;
     }
-
 
     parse_args(&g, argc, argv);
 
@@ -2650,6 +2681,8 @@ int main(int argc, char **argv)
                     "Acquired MANAGER selection for tray\n");
     }
 
+    write_status_file("started\n");
+
     g.vchan = libvchan_server_init(g.domid, 6000, 4096, 4096);
     if (!g.vchan) {
         fprintf(stderr, "vchan initialization failed\n");
@@ -2662,6 +2695,8 @@ int main(int argc, char **argv)
     vchan_register_at_eof(handle_guid_disconnect);
 
     handshake(&g);
+
+    write_status_file("connected\n");
 
     xfd = ConnectionNumber(g.display);
     struct pollfd fds[] = {

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -315,6 +315,7 @@ rm -f %{name}-%{version}
 /etc/qubes-rpc/qubes.SetMonitorLayout
 /etc/qubes-rpc/qubes.GuiVMSession
 /etc/qubes/post-install.d/20-qubes-guivm-gui-agent.sh
+/etc/qubes/post-install.d/20-qubes-gui-agent.sh
 %if 0%{?is_opensuse}
 %{_fillupdir}/desktop.qubes-gui-agent
 %else

--- a/selinux/qubes-gui-agent.fc
+++ b/selinux/qubes-gui-agent.fc
@@ -2,3 +2,4 @@
 /usr/bin/qubes-gui-runuser   -- gen_context(system_u:object_r:xdm_exec_t,s0)
 /usr/lib/qubes/qubes-xorg-wrapper -- gen_context(system_u:object_r:xserver_exec_t,s0)
 /usr/bin/qubes-run-xephyr -- gen_context(system_u:object_r:xserver_exec_t,s0)
+/run/qubes/gui-agent.status -- gen_context(system_u:object_r:qubes_gui_agent_state_file_t,s0)

--- a/selinux/qubes-gui-agent.te
+++ b/selinux/qubes-gui-agent.te
@@ -7,6 +7,9 @@ require {
 	class tcp_socket name_connect;
 }
 
+type qubes_gui_agent_state_file_t;
+files_type(qubes_gui_agent_state_file_t)
+
 allow xdm_t etc_t:file { create write };
 allow xdm_t self:passwd rootok;
 allow domain local_login_t:unix_stream_socket { rw_inherited_sock_file_perms ioctl };
@@ -16,6 +19,11 @@ init_domtrans_script(xdm_t)
 type_transition xdm_t qubes_var_run_t:sock_file qubes_qrexec_socket_t;
 manage_sock_files_pattern(xdm_t, qubes_var_run_t, qubes_qrexec_socket_t)
 write_sock_files_pattern(xdm_t, qubes_var_run_t, qubes_var_run_t)
+
+allow xdm_t qubes_gui_agent_state_file_t:file { create_file_perms write_file_perms delete_file_perms };
+allow xdm_t qubes_var_run_t:dir { add_entry_dir_perms del_entry_dir_perms };
+filetrans_pattern(xdm_t, qubes_var_run_t, qubes_gui_agent_state_file_t, file, "gui-agent.status")
+
 optional {
     pulseaudio_domtrans(xdm_t)
     dev_rw_xen(pulseaudio_t)


### PR DESCRIPTION
Until now, Xorg was started only after connecting with gui-daemon and
receiving xconf message. This was mostly because initial
resolution/video mem specified in the xorg.conf couldn't later be
changed and that affects maximum working resolution.

Since 49420c5 "Increase screen pixmap size beyond initial video RAM if
needed", this is no longer a problem. The only parameter (still) needed
before starting Xorg is GUI domain id, but this is available on the
command line. Change gui-agent to start Xorg earlier and only then wait
for gui-daemon. This allows starting all of the user session earlier,
optimizing startup time. This is especially relevant for VMs started on
boot (before user logs in), when GUI daemon isn't started yet. And also
helpful for preloaded disposables, which may start user session as part
of preloading now.

The current implementation is rather naive: it starts Xorg with
hardcoded 1920x1080 resolution (which will later be updated by the
qubes.SetMonitorLayout qrexec call), selects which events it want to
receive and then waits for the GUI daemon. Especially, no events are
actually processed before GUI daemon connects. This assumes all events
will be queued and can be processed after GUI daemon connection. Very
similar approach is already taken on GUI daemon re-connection, and it
works.

There is a potential issue, if too many events get queued before GUI
daemon connects and some get dropped. It's unclear how Xlib handles that
(and what is the limit), but if that happens there are two alternative
solutions:

1. Start processing events normally, especially collect info about all
relevant windows, but dont send anything to GUI daemon before it
connects - this basically requires changing write_struct() (and other
similar places) to check if GUI daemon is connected. And once GUI daemon
connects (first event received on the vchan FD), call
send_all_windows_info().

2. Wait for GUI daemon before registering for events, but then iterate
over all windows to collect necessary info and send it to dom0. This
approach theoretically can be more reliable (and might even allow
restarting gui-agent without restarting Xorg as a side effect), but it's
unclear if all data can be rebuilt this way. Especially tray icons may
be problematic, as it isn't any window property, but a message sent to
relevant selection owner (but theoretically
https://tronche.com/gui/x/icccm/sec-2.html#s-2.8 provides
solution for this issue).

https://github.com/QubesOS/qubes-issues/issues/9940#issuecomment-2847640715