### PR TITLE
Don't hang is-system-running when GUI is disabled

### DIFF
--- a/appvm-scripts/qubes-gui-agent.service
+++ b/appvm-scripts/qubes-gui-agent.service
@@ -9,6 +9,7 @@ TTYPath=/dev/tty7
 # custom PATH for X session can be set with ENV_PATH; otherwise service's PATH
 # is inherited
 #Environment=ENV_PATH=/usr/local/bin:/usr/bin:/bin
+ExecCondition=/bin/sh -c 'test "$(qubesdb-read --default=True /qubes-gui-enabled)" = "True"'
 ExecStartPre=/bin/sh -c /usr/lib/qubes/qubes-gui-agent-pre.sh
 ExecStart=/usr/bin/qubes-gui $GUI_OPTS
 # clean env


### PR DESCRIPTION
Else, it timesout and has a degraded status on the system space.

For: https://github.com/QubesOS/qubes-issues/issues/1512