### PR TITLE
Sync environment variables from the user session into systemd and dbus

### DIFF
--- a/appvm-scripts/usrbin/qubes-session
+++ b/appvm-scripts/usrbin/qubes-session
@@ -51,6 +51,10 @@ VMTYPE=$(/usr/bin/qubesdb-read /qubes-vm-type)
 UPDTYPE=$(/usr/bin/qubesdb-read /qubes-vm-updateable)
 [[ $UPDTYPE == 'True' ]] && UPDTYPE="UpdateableVM" || UPDTYPE="NonUpdateableVM"
 
+# Sync environment variables from the user session into the systemd user
+# manager and dbus-daemon
+dbus-update-activation-environment --systemd --all
+
 # process /etc/xdg/autostart and friends (according to Desktop Application
 # Autostart Specification)
 /usr/bin/qubes-session-autostart QUBES X-QUBES "X-$VMTYPE" "X-$UPDTYPE"


### PR DESCRIPTION
We're already syncing environment variables from the systemd user manager into the user session, but some variables may be set in the user session that aren't in the user manager or dbus-daemon by default. This interferes with applications that are launched by the user manager or dbus-daemon, such as Ptyxis and Kicksecure's fm-shim system.

Sync environment variables from the user session into the systemd user manager and dbus-daemon to fix this.

Fixes: https://github.com/QubesOS/qubes-issues/issues/10759
Fixes: https://github.com/QubesOS/qubes-issues/issues/10712

(Note that I haven't finished testing if this fixes the Ptyxis terminal issue, but it seems like it should. I'll report back once I've tested that.)