### PR TITLE
qubes-keymap.sh: preserve user layout across NetVM changes

### DIFF
--- a/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
+++ b/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
@@ -2,6 +2,9 @@
 
 # This file may be also executed by qubes-change-keyboard-layout
 
+# User-saved layout file (written by qubes-change-keyboard-layout)
+CUSTOM_LAYOUT_FILE="${HOME:-/root}/.config/qubes-keyboard-layout.rc"
+
 set_keyboard_layout() {
     KEYMAP="$1"
     # Default value
@@ -32,14 +35,45 @@ set_keyboard_layout() {
     done
 }
 
-QUBES_KEYMAP="$(/usr/bin/qubesdb-read /keyboard-layout)"
+# Read current live X11 keymap, return as layout+variant+options string
+get_live_layout() {
+    for x in /tmp/.X11-unix/X*; do
+        display="$(basename "$x")"
+        QUERY="$(setxkbmap -display ":${display#X}" -query 2>/dev/null)" || continue
+        LAYOUT="$(echo "$QUERY"  | awk '/^layout:/  {sub(/^layout:[[:space:]]+/,""); print}')"
+        VARIANT="$(echo "$QUERY" | awk '/^variant:/ {sub(/^variant:[[:space:]]+/,""); print}')"
+        OPTIONS="$(echo "$QUERY" | awk '/^options:/ {sub(/^options:[[:space:]]+/,""); print}')"
+        if [ -n "$LAYOUT" ]; then
+            echo "${LAYOUT}+${VARIANT}+${OPTIONS}"
+            return
+        fi
+    done
+}
+
+get_effective_layout() {
+    # Priority 1: user explicitly saved a layout via qubes-change-keyboard-layout
+    if [ -r "$CUSTOM_LAYOUT_FILE" ]; then
+        cat "$CUSTOM_LAYOUT_FILE"
+        return
+    fi
+    # Priority 2: preserve whatever X11 currently has (survives NetVM changes)
+    LIVE="$(get_live_layout)"
+    if [ -n "$LIVE" ]; then
+        echo "$LIVE"
+        return
+    fi
+    # Priority 3: fall back to dom0/GuiVM default
+    /usr/bin/qubesdb-read /keyboard-layout 2>/dev/null
+}
+
+QUBES_KEYMAP="$(/usr/bin/qubesdb-read /keyboard-layout 2>/dev/null)"
 
 if [ -n "$QUBES_KEYMAP" ]; then
   set_keyboard_layout "$QUBES_KEYMAP"
 fi
 
 while qubesdb-watch /keyboard-layout ; do
-  QUBES_KEYMAP="$(/usr/bin/qubesdb-read /keyboard-layout)"
+  QUBES_KEYMAP="$(get_effective_layout)"
   if [ -n "$QUBES_KEYMAP" ]; then
     set_keyboard_layout "$QUBES_KEYMAP"
   fi

--- a/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
+++ b/appvm-scripts/usr/lib/qubes/qubes-keymap.sh
@@ -7,7 +7,6 @@ CUSTOM_LAYOUT_FILE="${HOME:-/root}/.config/qubes-keyboard-layout.rc"
 
 set_keyboard_layout() {
     KEYMAP="$1"
-    # Default value
     if [ -z "$KEYMAP" ]; then
         KEYMAP=us
     fi
@@ -18,20 +17,16 @@ set_keyboard_layout() {
         KEYMAP_LAYOUT="$KEYMAP_LAYOUT,us"
         KEYMAP_VARIANT="$KEYMAP_VARIANT,"
     fi
-
     if [ -n "$KEYMAP_VARIANT" ]; then
         KEYMAP_VARIANT="-variant $KEYMAP_VARIANT"
     fi
-
     if [ -n "$KEYMAP_OPTIONS" ]; then
         KEYMAP_OPTIONS="-option -option $KEYMAP_OPTIONS"
     fi
-
-    # Set layout on all DISPLAY
-    for x in /tmp/.X11-unix/X*
-    do
+    for x in /tmp/.X11-unix/X*; do
         display="$(basename "$x")"
-        setxkbmap -display ":${display#X}" -layout "$KEYMAP_LAYOUT" $KEYMAP_VARIANT $KEYMAP_OPTIONS
+        setxkbmap -display ":${display#X}" -layout "$KEYMAP_LAYOUT" \
+            $KEYMAP_VARIANT $KEYMAP_OPTIONS
     done
 }
 
@@ -66,15 +61,16 @@ get_effective_layout() {
     /usr/bin/qubesdb-read /keyboard-layout 2>/dev/null
 }
 
+# On first start: apply dom0 default unconditionally (normal startup behaviour)
 QUBES_KEYMAP="$(/usr/bin/qubesdb-read /keyboard-layout 2>/dev/null)"
-
 if [ -n "$QUBES_KEYMAP" ]; then
-  set_keyboard_layout "$QUBES_KEYMAP"
+    set_keyboard_layout "$QUBES_KEYMAP"
 fi
 
-while qubesdb-watch /keyboard-layout ; do
-  QUBES_KEYMAP="$(get_effective_layout)"
-  if [ -n "$QUBES_KEYMAP" ]; then
-    set_keyboard_layout "$QUBES_KEYMAP"
-  fi
+# On subsequent QubesDB changes (e.g. NetVM change): preserve user's layout
+while qubesdb-watch /keyboard-layout; do
+    QUBES_KEYMAP="$(get_effective_layout)"
+    if [ -n "$QUBES_KEYMAP" ]; then
+        set_keyboard_layout "$QUBES_KEYMAP"
+    fi
 done


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#9892

When NetVM is changed, gui-daemon re-writes /keyboard-layout in QubesDB with the GuiVM default. The watch loop in qubes-keymap.sh fires and blindly applies it, resetting any custom layout set via setxkbmap.

Fix by reading the full live X11 layout (layout+variant+options) via setxkbmap -query on watch events, so user customizations survive NetVM changes. Falls back to QubesDB only when no custom layout is active. Also honours ~/.config/qubes-keyboard-layout.rc written by qubes-change-keyboard-layout.