### PR TITLE
Fix registering user session in sys-gui

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,8 @@ endif
 		$(DESTDIR)/etc/qubes-rpc/qubes.SetMonitorLayout
 	ln -sf ../../usr/bin/qubes-start-xephyr \
 		$(DESTDIR)/etc/qubes-rpc/qubes.GuiVMSession
+	install -d $(DESTDIR)/etc/qubes/rpc-config
+	echo "force-user='root'" > $(DESTDIR)/etc/qubes/rpc-config/qubes.GuiVMSession
 	install -D window-icon-updater/icon-sender \
 		$(DESTDIR)/usr/lib/qubes/icon-sender
 	install -m 0644 -D window-icon-updater/qubes-icon-sender.desktop \

--- a/appvm-scripts/usrbin/qubes-start-xephyr
+++ b/appvm-scripts/usrbin/qubes-start-xephyr
@@ -1,8 +1,15 @@
 #!/bin/sh
 
-if [ $(whoami) == "root" ]; then
-    echo "Should be run as normal user!"
-    exit 1
+# Start under new service unit, to detach from the current non-gui logind
+# session
+if [ -z "$INVOCATION_ID" ]; then
+    exec systemd-run --system \
+        --unit=qubes-gui-agent-session.service \
+        --description="Start GUI session via Xephyr" \
+        --property=TTYPath=/dev/tty8 \
+        --property=StandardInput=tty \
+        --wait \
+        -- "$0" "$@"
 fi
 
 # do not let child processes believe they are running as qrexec service
@@ -29,6 +36,11 @@ if ! timeout 30s sh -c "while ! xdpyinfo -display $DISPLAY_XORG > /dev/null 2>&1
     exit 1
 fi
 
+# parameters for logind session
+export DISPLAY=$DISPLAY_XEPHYR
+export XDG_SEAT=seat0
+export XDG_SESSION_CLASS=user
+
 # Run xsession into Xephyr
-export DISPLAY=$DISPLAY_XORG
-exec /usr/bin/xinit $XSESSION -- /usr/bin/qubes-run-xephyr $DISPLAY_XEPHYR > ~/.xsession-errors 2>&1
+user=$(qubesdb-read --default=user /default-user)
+exec /usr/bin/qubes-gui-runuser $user /usr/bin/env env DISPLAY=$DISPLAY_XORG /usr/bin/xinit $XSESSION -- /usr/bin/qubes-run-xephyr $DISPLAY_XEPHYR > ~/.xsession-errors 2>&1

--- a/debian/qubes-gui-agent.install
+++ b/debian/qubes-gui-agent.install
@@ -11,6 +11,7 @@ etc/qubes-rpc/qubes.SetMonitorLayout
 etc/qubes-rpc/qubes.GuiVMSession
 etc/qubes/post-install.d/20-qubes-guivm-gui-agent.sh
 etc/qubes/post-install.d/20-qubes-gui-agent.sh
+etc/qubes/rpc-config/qubes.GuiVMSession
 etc/xdg/autostart/qubes-gtk4-workarounds.desktop
 etc/xdg/autostart/qubes-icon-sender.desktop
 etc/xdg/autostart/qubes-qrexec-fork-server.desktop

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -321,6 +321,7 @@ rm -f %{name}-%{version}
 /etc/qubes-rpc/qubes.GuiVMSession
 /etc/qubes/post-install.d/20-qubes-guivm-gui-agent.sh
 /etc/qubes/post-install.d/20-qubes-gui-agent.sh
+/etc/qubes/rpc-config/qubes.GuiVMSession
 %if 0%{?is_opensuse}
 %{_fillupdir}/desktop.qubes-gui-agent
 %else


### PR DESCRIPTION
Starting Xorg for sys-gui (on display :1) intentionally skips
qubes-gui-runuser and uses plain runuser - which doesn't register
graphical session in systemd-logind. This is okay, because actual user
session is running under Xephyr on display :0. But starting Xephyr was
missing qubes-gui-runuser call too.

Not registered user session caused at least `loginctl lock-session` not
working. There might be more issues caused by this.

Fix this by adding qubes-gui-runuser in qubes-start-xephyr script. This
is a bit more involved, because:
1. When started as qrexec service (which is the case normally), it's
   already running under registered user session, and logind refuses to
   create another one for that process. Fix this by using systemd-run,
   to run the actual service under new systemd unit, without user
   session yet, on a fresh terminal (tty8, as tty7 is used by Xorg :1
   already).
2. Non-privileged user is not allowed to create new sessions. Fix this
   by adding force-user='root' to the service configuration (and
   removing check that refuses root).

Finally, the qubes-gui-runuser call is a bit complicated, because
qubes-gui-runuser needs to have DISPLAY=:0 - to register this one in
logind. But then, Xephyr needs to be started with DISPLAY=:1 to display
its window there. Add extra 'env' call in between to adjust DISPLAY
variable appropriately.

Fixes https://github.com/QubesOS/qubes-issues/issues/10890
