### PR TITLE
Remove duplicate buttons using xfconf-query for xfce-based VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,6 +239,8 @@ endif
 		$(DESTDIR)/usr/lib/qubes/qubes-xorg-wrapper
 	install -D appvm-scripts/usr/lib/qubes/gtk4-workarounds.sh \
 		$(DESTDIR)/usr/lib/qubes/gtk4-workarounds.sh
+	install -m 0644 -D appvm-scripts/etc/xdgautostart/qubes-set-xsettings-xfconf-query.desktop \
+		$(DESTDIR)/etc/xdg/autostart/qubes-set-xsettings-xfconf-query.desktop
 ifeq ($(shell lsb_release -is), Debian)
 	install -D -m 0644 appvm-scripts/etc/pam.d/qubes-gui-agent.debian \
 		$(DESTDIR)/etc/pam.d/qubes-gui-agent

--- a/appvm-scripts/etc/xdgautostart/qubes-set-xsettings-xfconf-query.desktop
+++ b/appvm-scripts/etc/xdgautostart/qubes-set-xsettings-xfconf-query.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Version=1.0
+Encoding=UTF-8
+TryExec=xfconf-query
+Exec=xfconf-query --channel xsettings --property /Gtk/DecorationLayout --create --type string --set ""
+Terminal=false
+Type=Application
+OnlyShowIn=X-QUBES;

--- a/debian/qubes-gui-agent-xfce.install
+++ b/debian/qubes-gui-agent-xfce.install
@@ -1,1 +1,2 @@
 etc/X11/Xsession.d/60xfce-desktop
+etc/xdg/autostart/qubes-set-xsettings-xfconf-query.desktop

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -371,6 +371,7 @@ rm -f %{name}-%{version}
 
 %files xfce
 %{xinitrc_dir}/60xfce-desktop.sh
+/etc/xdg/autostart/qubes-set-xsettings-xfconf-query.desktop
 
 %files -n qubes-gui-vnc
 #/lib/systemd/system/qubes-gui-vncserver.service


### PR DESCRIPTION
In the gnome-based template, xsettingsd was used to remove duplicate buttons. However, since xfce-based templates use xfsettingsd, xfconf-query is called at session startup to perform the same configuration.

Previously: https://github.com/QubesOS/qubes-gui-agent-linux/pull/256