### PR TITLE
sys-gui: copy dpi from the host display

### DIFF
--- a/appvm-scripts/usrbin/qubes-run-xephyr
+++ b/appvm-scripts/usrbin/qubes-run-xephyr
@@ -8,4 +8,9 @@ elif [ -e /usr/lib64/qubes-gui-daemon/shmoverride.so ]; then
     SHMOVERRIDE=/usr/lib64/qubes-gui-daemon/shmoverride.so
 fi
 
+DPI=$(xdpyinfo | sed -n '/resolution:/s/.* \([0-9]\+\)x[0-9]\+.*/\1/p')
+if [ -n "$DPI" ]; then
+    OPTIONS_XEPHYR="$OPTIONS_XEPHYR -dpi $DPI"
+fi
+
 LD_PRELOAD=$SHMOVERRIDE /usr/bin/Xephyr $OPTIONS_XEPHYR "$DISPLAY_XEPHYR" > ~/.xephyr-errors 2>&1


### PR DESCRIPTION
... instead of using hardcoded default of 75.
This is especially relevant with Xfce change to automatically detect
DPI.

QubesOS/qubes-issues#10840
