### PR TITLE
Start graphical-session.target together with qubes-session

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,8 @@ install-pipewire:
 install-systemd:
 	install -m 0644 -D appvm-scripts/qubes-gui-agent.service \
 		$(DESTDIR)$(UNITDIR)/qubes-gui-agent.service
+	install -m 0644 -D appvm-scripts/lib/systemd/user/qubes-graphical-session.target \
+		$(DESTDIR)$(USERUNITDIR)/qubes-graphical-session.target
 
 .PHONY: install-common
 install-common:

--- a/appvm-scripts/lib/systemd/user/qubes-graphical-session.target
+++ b/appvm-scripts/lib/systemd/user/qubes-graphical-session.target
@@ -1,0 +1,3 @@
+[Unit]
+Description=Qubes graphical session
+BindsTo=graphical-session.target

--- a/appvm-scripts/usrbin/qubes-session
+++ b/appvm-scripts/usrbin/qubes-session
@@ -55,6 +55,11 @@ UPDTYPE=$(/usr/bin/qubesdb-read /qubes-vm-updateable)
 # manager and dbus-daemon
 dbus-update-activation-environment --systemd --all
 
+if command -v systemctl >/dev/null && [ -e "${XDG_RUNTIME_DIR:-/run/user/$UID}/systemd" ]; then
+    trap "systemctl --user stop qubes-graphical-session.target" EXIT
+    systemctl --user start qubes-graphical-session.target
+fi
+
 # process /etc/xdg/autostart and friends (according to Desktop Application
 # Autostart Specification)
 /usr/bin/qubes-session-autostart QUBES X-QUBES "X-$VMTYPE" "X-$UPDTYPE"

--- a/debian/qubes-gui-agent.install
+++ b/debian/qubes-gui-agent.install
@@ -23,6 +23,7 @@ etc/xdg/xsettingsd
 lib/systemd/system/qubes-gui-agent.service
 lib/udev/rules.d/70-master-of-seat.rules
 lib/udev/rules.d/90-qubes-virtual-input-device.rules
+lib/systemd/user/qubes-graphical-session.target
 usr/bin/qubes-change-keyboard-layout
 usr/bin/qubes-gui
 usr/bin/qubes-gui-runuser

--- a/rpm_spec/gui-agent.spec.in
+++ b/rpm_spec/gui-agent.spec.in
@@ -328,6 +328,7 @@ rm -f %{name}-%{version}
 %config /etc/sysconfig/desktop
 %endif
 %_unitdir/qubes-gui-agent.service
+%{_userunitdir}/qubes-graphical-session.target
 %_udevrulesdir/70-master-of-seat.rules
 %_udevrulesdir/90-qubes-virtual-input-device.rules
 %_sysctldir/30-qubes-gui-agent.conf


### PR DESCRIPTION
Start a dummy qubes-graphical-session.target when qubes-session finishes
setting things up, and schedule its stop when qubes-session is stopped.
Use qubes-graphical-session.target, because graphical-session.target
cannot be started directly.

This allows starting GUI applications via systemd user services.

Fixes QubesOS/qubes-issues#9576
