### PR TITLE
Fix XEmbed tray docking initialization

### DIFF
--- a/gui-agent/vmside.c
+++ b/gui-agent/vmside.c
@@ -1410,6 +1410,7 @@ static void process_xevent_message(Ghandles * g, XClientMessageEvent * ev)
         Window w;
         int ret;
         struct msg_hdr hdr;
+        struct msg_configure conf;
         Atom act_type;
         int act_fmt;
         int mapwindow = 0;
@@ -1442,7 +1443,7 @@ static void process_xevent_message(Ghandles * g, XClientMessageEvent * ev)
                     fprintf(stderr, "window 0x%lx havn't proper _XEMBED_INFO property, assuming defaults (workaround for buggy applications)\n", w);
                 }
                 if (act_type == g->xembed_info && nitems == 2) {
-                    mapwindow = ((int*)data)[1] & XEMBED_MAPPED;
+                    mapwindow = ((unsigned long*)data)[1] & XEMBED_MAPPED;
                     /* TODO: handle version */
                 }
                 if (ret == Success && nitems > 0)
@@ -1486,17 +1487,26 @@ static void process_xevent_message(Ghandles * g, XClientMessageEvent * ev)
                 resp.data.l[4] = 0; /* TODO: handle version; GTK+ uses version 1, but spec says the latest is 0 */
                 resp.display = g->display;
                 XSendEvent(resp.display, resp.window, False,
-                        NoEventMask, (XEvent *) & ev);
+                        NoEventMask, (XEvent *) &resp);
                 XRaiseWindow(g->display, w);
                 if (mapwindow)
                     XMapRaised(g->display, resp.window);
                 XMapWindow(g->display, wd->embeder);
                 XLowerWindow(g->display, wd->embeder);
-                XMoveWindow(g->display, w, 0, 0);
+                XMoveResizeWindow(g->display, w, 0, 0, 32, 32);
                 /* force refresh of window content */
                 XClearWindow(g->display, wd->embeder);
                 XClearArea(g->display, w, 0, 0, 32, 32, True); /* XXX defult size once again */
                 XSync(g->display, False);
+
+                hdr.type = MSG_CONFIGURE;
+                hdr.window = w;
+                conf.x = 0;
+                conf.y = 0;
+                conf.width = 32;
+                conf.height = 32;
+                conf.override_redirect = 0;
+                write_message(g->vchan, hdr, conf);
 
                 hdr.type = MSG_DOCK;
                 hdr.window = w;


### PR DESCRIPTION
## Summary

Fix XEmbed tray clients that remain mapped as blank `1x1` icons when proxied to a desktop tray.

The live tray-docking path now:

- sends the constructed `XEMBED_EMBEDDED_NOTIFY` event instead of the address of the incoming-event pointer;
- reads `XEMBED_MAPPED` using the `unsigned long` representation returned by `XGetWindowProperty()`;
- sizes the client to the existing `32x32` default embedder geometry; and
- sends that geometry to the GUI daemon before `MSG_DOCK`, matching the ordering used when full window state is resent.

## Root cause

The incorrect `XSendEvent()` argument prevented clients from receiving `XEMBED_EMBEDDED_NOTIFY`.

Fixing only that call was insufficient for clients initially created at `1x1`: dom0 still knew the pre-dock window as `1x1` and configured the docked client back to that size. Additionally, reading a format-32 X property through `int *` selects the wrong slot on 64-bit systems, so the mapped flag could be missed.

## Validation

- Rebuilt `gui-agent/qubes-gui` from a clean object state with the project's `-Wall -Wextra -Werror` flags.
- Tested on Qubes OS 4.3 with Fedora 43 guests and KDE Plasma/X11 plus `xembedsniproxy` in dom0.
- A minimal XEmbed client initially created at `1x1` changed from receiving no embedded notification and remaining `1x1` to receiving `XEMBED_EMBEDDED_NOTIFY`, `MapNotify`, and a stable `32x32` configure event.
- Verified directly in the guest as `32x32` and `IsViewable`.
- Tested the resulting agent in `sys-net` with the real `nm-applet`; the previously blank NetworkManager icon became visible and was tinted with the qube's red label color.

## AI assistance disclosure

This change was developed and tested with assistance from OpenAI Codex. The runtime tests and final visual confirmation were performed interactively on the affected Qubes OS system.
